### PR TITLE
chore: bump ai-hero-cli to 0.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
         "@types/react": "^19.2.7",
         "@types/react-dom": "^19.2.3",
         "@types/youtube": "^0.1.2",
-        "ai-hero-cli": "^0.5.0",
+        "ai-hero-cli": "^0.6.0",
         "drizzle-kit": "^0.31.4",
         "prettier": "^3.8.1",
         "shadcn": "^3.8.4",
@@ -5097,9 +5097,9 @@
       }
     },
     "node_modules/ai-hero-cli": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/ai-hero-cli/-/ai-hero-cli-0.5.0.tgz",
-      "integrity": "sha512-zTlC0PpC88/RoLKL25Bx/lCgyj0CDN23ymgr1gSh5oL9/bzZyDQ/KxggNrygjQZJ2wwe3UuhmWRNTvF4kNOxRA==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/ai-hero-cli/-/ai-hero-cli-0.6.0.tgz",
+      "integrity": "sha512-Jmj70LO6LwC3zKqe3px63f+vXVUy+/tP/DClixNlJZ5a7lr+pRXqtXbb9JwqPBpfAtF3AZLccLoTayLCkpuTyw==",
       "dev": true,
       "license": "MIT",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "@types/react": "^19.2.7",
     "@types/react-dom": "^19.2.3",
     "@types/youtube": "^0.1.2",
-    "ai-hero-cli": "^0.5.0",
+    "ai-hero-cli": "^0.6.0",
     "drizzle-kit": "^0.31.4",
     "prettier": "^3.8.1",
     "shadcn": "^3.8.4",


### PR DESCRIPTION
Bumps the `ai-hero-cli` devDependency on `main` from `^0.5.0` to `^0.6.0` (current npm latest), plus the matching `package-lock.json` entry. Nothing else changes.

## Why it's safe

- The published bin is still named `ai-hero-cli` in both 0.5.0 and 0.6.0 (the repo's `bin` field says `ai-hero`, but `publishConfig.directory: dist` means the published package exposes `ai-hero-cli`), so the `reset` / `cherry-pick` / `pull` scripts keep resolving.
- Verified against `npx ai-hero-cli@0.6.0 --help`: `reset`, `cherry-pick` and `pull` all still exist and still accept the exact flags the scripts pass (`--branch`, `--upstream`).

## What 0.6.0 brings

- **New `fork` command** — turns a student's course clone into a fresh private GitHub repo they own (`ai-hero-cli fork [repo-name]`). Not wired into `package.json` scripts here; worth a follow-up if we want `pnpm fork`.
- **`internal edit-commit` is interactive again** — the `begin` / `continue` / `status` / `abort` / `publish` subcommands and the `.git/ai-hero/edit-commit.json` session file are **removed**. Maintainer-facing only, but it changes how lesson commits get edited.
- Slug lesson ids (landed in 0.5.0) now also work for `internal edit-commit --commit`.

## Follow-up

`live-run-through` is a strict superset of `main`, so once this merges it needs `git rebase main live-run-through` and a `--force-with-lease` push. Left out of this PR deliberately — rewriting the shared lesson stack should be a separate, deliberate step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)