### PR TITLE
fix(request-logger): redact the x-goog-api-key header

### DIFF
--- a/request-logger/render.test.ts
+++ b/request-logger/render.test.ts
@@ -359,4 +359,18 @@ describe("renderMarkdown header redaction", () => {
     expect(out).not.toContain("secret-token");
     expect(out).toContain("[REDACTED]");
   });
+
+  it("hides the x-goog-api-key header", () => {
+    const out = renderMarkdown({
+      ...BASE,
+      agent: "Gemini CLI",
+      renderer: "gemini",
+      headers: { "x-goog-api-key": "secret-goog-key" },
+      path: "/v1beta/models/gemini-2.5-pro:generateContent",
+      requestBody: body(GEMINI_REQUEST),
+      responseRaw: "",
+    });
+    expect(out).not.toContain("secret-goog-key");
+    expect(out).toContain("[REDACTED]");
+  });
 });

--- a/request-logger/render.ts
+++ b/request-logger/render.ts
@@ -34,7 +34,12 @@ interface RenderInput {
   responseRaw: string;
 }
 
-const REDACT = new Set(["authorization", "x-api-key", "api-key"]);
+const REDACT = new Set([
+  "authorization",
+  "x-api-key",
+  "api-key",
+  "x-goog-api-key",
+]);
 
 /**
  * Turn the raw request bytes into text.


### PR DESCRIPTION
Gemini sends its API key in the `x-goog-api-key` header. The request-logger `REDACT` set held only `authorization`, `x-api-key` and `api-key`, so a student running the logger against their own Gemini key got that key written in plain text into the Markdown log — a log the course asks them to read and share.

## Changes

- Add `x-goog-api-key` to `REDACT` in `request-logger/render.ts`.
- Add a test in `request-logger/render.test.ts` that proves the value is replaced with `[REDACTED]`.

## Verification

`pnpm vitest run request-logger` — 145 tests pass.

## Note for the maintainer

`request-logger/render.ts` is on `main`, not in the lesson stack. After this merges, move the 25-commit stack onto the new `main`:

```
git branch backup/live-run-through-pre-redact-$(date +%s)
git rebase --onto main <old-main-sha> live-run-through
git push --force-with-lease origin live-run-through
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)