### PR TITLE
chore: ignore .vscode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,9 @@
 # JetBrains
 /.idea/
 
+# VS Code
+.vscode/
+
 # request-logger captured logs (may contain your own code/prompts)
 /request-logger/logs/*
 !/request-logger/logs/.gitkeep


### PR DESCRIPTION
## Summary
- Adds `.vscode/` to `.gitignore` so editor-local VS Code settings don't get committed, matching the existing JetBrains `/.idea/` ignore.

## Test plan
- N/A — gitignore-only change.