### PR TITLE
request-logger: support Oh My Pi and local model servers

### DIFF
--- a/request-logger/README.md
+++ b/request-logger/README.md
@@ -58,6 +58,7 @@ from this table. It is here so you can see what is supported before you start.
 | GitHub Copilot   | Yes   | Your normal subscription login.                  |
 | OpenCode         | Yes   | One command, or a config file.                   |
 | Pi               | Yes   | A config file. Pi has no base URL variable.      |
+| Oh My Pi         | Yes   | One command, or a config file plus a flag.       |
 | Gemini CLI       | Yes   | One command. The free Google login works.        |
 | Cursor CLI       | No    | Nothing can make it work. See below.             |
 | Amp              | No    | Nothing can make it work. See below.             |
@@ -158,6 +159,10 @@ Different agents fan out differently, and that is worth watching:
 - **OpenCode** never counts tokens. Instead it makes a second call with a small
   model to title the thread, so one turn writes exactly two captures.
 - **Pi** never counts tokens at all, so every file is a real turn.
+- **Oh My Pi** never counts tokens at all, so every file is a real turn. It
+  does make small background calls with a smaller model, such as titling a
+  session, and when that model runs on the chosen provider each turn writes a
+  few extra small captures alongside the real one.
 - **Gemini** on the free Google login makes several extra calls that carry no
   prompt. Those are not logged either.
 

--- a/request-logger/agents.test.ts
+++ b/request-logger/agents.test.ts
@@ -3,6 +3,7 @@ import {
   ISSUE_URL,
   listAgents,
   listProviders,
+  localUpstream,
   OTHER_ID,
   resolveChoice,
   shouldLogRequest,
@@ -67,6 +68,7 @@ describe("listAgents", () => {
       "copilot",
       "opencode",
       "pi",
+      "omp",
       "gemini",
       "cursor",
       "amp",
@@ -126,6 +128,15 @@ describe("listProviders", () => {
   it("leads Pi with the Anthropic route, which is the simplest", () => {
     expect(listProviders("pi")[0].id).toBe("anthropic");
   });
+
+  it("returns all four Oh My Pi providers, local last", () => {
+    expect(listProviders("omp").map((p) => p.id)).toEqual([
+      "anthropic",
+      "openai",
+      "codex",
+      "local",
+    ]);
+  });
 });
 
 describe("resolveChoice — upstream hosts", () => {
@@ -167,6 +178,18 @@ describe("resolveChoice — upstream hosts", () => {
 
   it("does not send Pi on a ChatGPT subscription to the OpenAI host", () => {
     expect(target("pi", "codex").upstreamHost).not.toBe("api.openai.com");
+  });
+
+  it("sends Oh My Pi on Anthropic to Anthropic", () => {
+    expect(target("omp", "anthropic").upstreamHost).toBe("api.anthropic.com");
+  });
+
+  it("sends Oh My Pi on OpenAI to OpenAI", () => {
+    expect(target("omp", "openai").upstreamHost).toBe("api.openai.com");
+  });
+
+  it("sends Oh My Pi on a ChatGPT subscription to the ChatGPT host", () => {
+    expect(target("omp", "codex").upstreamHost).toBe("chatgpt.com");
   });
 
   it("sends Gemini on an API key to the public API host", () => {
@@ -214,6 +237,15 @@ describe("resolveChoice — renderers", () => {
     expect(target("pi", "codex").renderer).toBe("openai");
   });
 
+  it("reads Oh My Pi on Anthropic with the Anthropic renderer", () => {
+    expect(target("omp", "anthropic").renderer).toBe("anthropic");
+  });
+
+  it("reads both Oh My Pi OpenAI routes with the OpenAI renderer", () => {
+    expect(target("omp", "openai").renderer).toBe("openai");
+    expect(target("omp", "codex").renderer).toBe("openai");
+  });
+
   it("reads both Gemini routes with the Gemini renderer", () => {
     expect(target("gemini", "api-key").renderer).toBe("gemini");
     expect(target("gemini", "google-login").renderer).toBe("gemini");
@@ -247,6 +279,20 @@ describe("resolveChoice — base URLs", () => {
     // Pi appends /codex/responses itself, and the real endpoint sits under
     // /backend-api. Without the suffix the forwarded path loses that segment.
     expect(target("pi", "codex").baseUrl).toBe("http://localhost:8787/backend-api");
+  });
+
+  it("gives Oh My Pi on Anthropic no suffix, because its SDK adds /v1/messages", () => {
+    expect(target("omp", "anthropic").baseUrl).toBe("http://localhost:8787");
+  });
+
+  it("gives Oh My Pi on OpenAI the /v1 suffix, because that transport adds only /responses", () => {
+    expect(target("omp", "openai").baseUrl).toBe("http://localhost:8787/v1");
+  });
+
+  it("gives Oh My Pi on a ChatGPT subscription the /backend-api suffix", () => {
+    // omp appends /codex/responses itself, and the real endpoint sits under
+    // /backend-api. Without the suffix the forwarded path loses that segment.
+    expect(target("omp", "codex").baseUrl).toBe("http://localhost:8787/backend-api");
   });
 
   it("uses the port it is given", () => {
@@ -341,6 +387,24 @@ describe("resolveChoice — commands", () => {
   it("gives Pi a bare command, because Pi has no base URL variable", () => {
     expect(target("pi", "anthropic").command).toBe("pi");
   });
+
+  it("sets the base URL for Oh My Pi with its Anthropic variable", () => {
+    expect(target("omp", "anthropic").command).toBe(
+      "ANTHROPIC_BASE_URL=http://localhost:8787 omp"
+    );
+  });
+
+  it("gives Oh My Pi on OpenAI a bare command, because there is no variable on that route", () => {
+    expect(target("omp", "openai").command).toBe("omp");
+  });
+
+  it("forces Oh My Pi's Codex route onto SSE and keeps the endpoint out of the command", () => {
+    // The endpoint comes from the models file, so the command must not carry
+    // a base URL.
+    const command = target("omp", "codex").command;
+    expect(command).toBe("PI_CODEX_WEBSOCKET=false omp");
+    expect(command).not.toContain("http://localhost:8787");
+  });
 });
 
 describe("resolveChoice — setup files", () => {
@@ -399,6 +463,33 @@ describe("resolveChoice — setup files", () => {
 
   it("gives Pi on Anthropic only one file to write", () => {
     expect(target("pi", "anthropic").setup).toHaveLength(1);
+  });
+
+  it("gives Oh My Pi on Anthropic no file to write, because the variable does the job", () => {
+    expect(target("omp", "anthropic").setup).toEqual([]);
+  });
+
+  it("gives Oh My Pi its models file on the OpenAI route", () => {
+    expect(target("omp", "openai").setup[0].path).toBe("~/.omp/agent/models.yml");
+    expect(target("omp", "openai").setup[0].body).toContain(
+      "baseUrl: http://localhost:8787/v1"
+    );
+    expect(target("omp", "openai").setup[0].body).toContain("openai");
+  });
+
+  it("gives Oh My Pi its models file on the Codex route, naming the hyphenated provider", () => {
+    const body = target("omp", "codex").setup[0].body;
+    expect(target("omp", "codex").setup[0].path).toBe("~/.omp/agent/models.yml");
+    expect(body).toContain("baseUrl: http://localhost:8787/backend-api");
+    expect(body).toContain("openai-codex");
+  });
+
+  it("does not put a transport in the Oh My Pi models file, where it would mean the auth gateway", () => {
+    expect(target("omp", "codex").setup[0].body).not.toContain("transport");
+  });
+
+  it("gives Oh My Pi only one file on the OpenAI route", () => {
+    expect(target("omp", "openai").setup).toHaveLength(1);
   });
 });
 
@@ -497,6 +588,12 @@ describe("shouldLogRequest", () => {
     expect(shouldLogRequest("POST", "/v1/responses", "openai")).toBe(true);
   });
 
+  it("logs a real Codex turn on the backend-api path", () => {
+    expect(
+      shouldLogRequest("POST", "/backend-api/codex/responses", "openai")
+    ).toBe(true);
+  });
+
   it("logs a streaming Gemini turn", () => {
     expect(
       shouldLogRequest(
@@ -577,5 +674,143 @@ describe("resolveChoice — bad input", () => {
   it("points the student at --force when a choice cannot be resolved", () => {
     const result = resolveChoice({ agent: "nonesuch" }, PORT);
     expect(result.kind === "error" && result.message).toContain("--force");
+  });
+});
+
+describe("localUpstream", () => {
+  it("parses a plain localhost address", () => {
+    expect(localUpstream("http://127.0.0.1:8000")).toEqual({
+      scheme: "http",
+      host: "127.0.0.1",
+      port: 8000,
+      prefix: "",
+    });
+  });
+
+  it("strips a trailing /v1, because the requests already carry it", () => {
+    expect(localUpstream("http://127.0.0.1:8000/v1")).toEqual({
+      scheme: "http",
+      host: "127.0.0.1",
+      port: 8000,
+      prefix: "",
+    });
+  });
+
+  it("keeps a server subpath as the forward prefix", () => {
+    expect(localUpstream("http://127.0.0.1:8000/my-model")).toEqual({
+      scheme: "http",
+      host: "127.0.0.1",
+      port: 8000,
+      prefix: "/my-model",
+    });
+  });
+
+  it("defaults the port from the scheme when none is given", () => {
+    expect(localUpstream("http://localhost").port).toBe(80);
+    expect(localUpstream("https://localhost").port).toBe(443);
+  });
+
+  it("reports the scheme", () => {
+    expect(localUpstream("https://127.0.0.1:8443").scheme).toBe("https");
+    expect(localUpstream("http://127.0.0.1:8000").scheme).toBe("http");
+  });
+
+  it("rejects something that is not a URL", () => {
+    expect(() => localUpstream("127.0.0.1:8000")).toThrow();
+  });
+
+  it("rejects a scheme a local model server does not speak", () => {
+    expect(() => localUpstream("ftp://127.0.0.1:8000")).toThrow();
+  });
+});
+
+describe("resolveChoice — local model", () => {
+  it("reads a local model with the OpenAI renderer, because that is the wire", () => {
+    const result = resolveChoice(
+      { agent: "omp", provider: "local", localUrl: "http://127.0.0.1:8000", localModel: "llama3" },
+      PORT
+    );
+    if (result.kind !== "target") throw new Error(`got ${result.kind}`);
+    expect(result.renderer).toBe("openai");
+  });
+
+  it("dials the student's server, not a cloud host", () => {
+    const result = resolveChoice(
+      { agent: "omp", provider: "local", localUrl: "http://127.0.0.1:8000", localModel: "llama3" },
+      PORT
+    );
+    if (result.kind !== "target") throw new Error(`got ${result.kind}`);
+    expect(result.upstreamHost).toBe("127.0.0.1");
+    expect(result.upstreamPort).toBe(8000);
+    expect(result.upstreamScheme).toBe("http");
+    expect(result.upstreamPrefix).toBe("");
+  });
+
+  it("carries a server subpath in the forward prefix", () => {
+    const result = resolveChoice(
+      { agent: "omp", provider: "local", localUrl: "http://127.0.0.1:8000/my-model", localModel: "llama3" },
+      PORT
+    );
+    if (result.kind !== "target") throw new Error(`got ${result.kind}`);
+    expect(result.upstreamPrefix).toBe("/my-model");
+  });
+
+  it("keeps the base URL on the tool, not the server", () => {
+    const result = resolveChoice(
+      { agent: "omp", provider: "local", localUrl: "http://127.0.0.1:8000", localModel: "llama3" },
+      PORT
+    );
+    if (result.kind !== "target") throw new Error(`got ${result.kind}`);
+    expect(result.baseUrl).toBe("http://localhost:8787/v1");
+  });
+
+  it("pins the model and the background model to the local one", () => {
+    const result = resolveChoice(
+      { agent: "omp", provider: "local", localUrl: "http://127.0.0.1:8000", localModel: "llama3" },
+      PORT
+    );
+    if (result.kind !== "target") throw new Error(`got ${result.kind}`);
+    expect(result.command).toBe("omp --model local/llama3 --smol local/llama3");
+  });
+
+  it("writes a local provider that lists the chosen model and no key", () => {
+    const result = resolveChoice(
+      { agent: "omp", provider: "local", localUrl: "http://127.0.0.1:8000", localModel: "llama3" },
+      PORT
+    );
+    if (result.kind !== "target") throw new Error(`got ${result.kind}`);
+    const file = result.setup[0];
+    expect(file.path).toBe("~/.omp/agent/models.yml");
+    expect(file.body).toContain("baseUrl:");
+    expect(file.body).toContain("http://localhost:8787/v1");
+    expect(file.body).toContain("auth: none");
+    expect(file.body).toContain("api: openai-completions");
+    expect(file.body).toContain("llama3");
+  });
+
+  it("is an error without the server address, because there is nothing to guess", () => {
+    const result = resolveChoice(
+      { agent: "omp", provider: "local", localModel: "llama3" },
+      PORT
+    );
+    expect(result.kind).toBe("error");
+  });
+
+  it("is an error when the address is not a URL", () => {
+    const result = resolveChoice(
+      { agent: "omp", provider: "local", localUrl: "not a url", localModel: "llama3" },
+      PORT
+    );
+    expect(result.kind).toBe("error");
+  });
+});
+
+describe("shouldLogRequest — local model", () => {
+  it("logs a local turn on the OpenAI wire", () => {
+    expect(shouldLogRequest("POST", "/v1/chat/completions", "openai")).toBe(true);
+  });
+
+  it("does not log the model discovery probe", () => {
+    expect(shouldLogRequest("GET", "/v1/models", "openai")).toBe(false);
   });
 });

--- a/request-logger/agents.ts
+++ b/request-logger/agents.ts
@@ -17,10 +17,20 @@
 
 export type RendererId = "anthropic" | "openai" | "gemini";
 
-/** What the student picked. This, and only this, is what gets saved to disk. */
+/**
+ * What the student picked. This, and only this, is what gets saved to disk.
+ *
+ * The local* fields exist only for a local (locally hosted) model. The wizard
+ * fills them by probing the URL the student types in, so a plain resolveChoice
+ * call with no localUrl on a local provider is an error, not a guess.
+ */
 export interface AgentChoice {
   agent: string;
   provider?: string;
+  /** The address of the student's local model server, e.g. http://127.0.0.1:8000 */
+  localUrl?: string;
+  /** The model id the probe found, or the one the student picked. */
+  localModel?: string;
 }
 
 export interface ResolvedTarget {
@@ -32,6 +42,15 @@ export interface ResolvedTarget {
   /** The single host every request is forwarded to. */
   upstreamHost: string;
   renderer: RendererId;
+  /** Scheme of the upstream. Always https for a cloud provider; http for a local server. */
+  upstreamScheme: "http" | "https";
+  /** Port of the upstream. 443 for a cloud provider; the server's port for a local one. */
+  upstreamPort: number;
+  /**
+   * Path prepended to the received path before forwarding. Empty for a cloud
+   * provider; the student's server subpath for a local one.
+   */
+  upstreamPrefix: string;
   /** The base URL the student points their agent at, e.g. http://localhost:8787/v1 */
   baseUrl: string;
   /** The copy-pasteable command, complete with env vars and flags. */
@@ -103,8 +122,19 @@ export interface SetupFile {
 interface ProviderEntry {
   id: string;
   label: string;
+  /**
+   * The host every request is forwarded to. For a local provider this is a
+   * placeholder; the real host and port come from the student's URL at resolve
+   * time, because they differ per machine.
+   */
   upstreamHost: string;
   renderer: RendererId;
+  /**
+   * True when this provider points at a locally hosted model instead of a cloud
+   * API. The student supplies the server's address; the tool probes it to learn
+   * the wire format and a model to use.
+   */
+  local?: boolean;
   /**
    * Appended to http://localhost:PORT to make the base URL.
    *
@@ -165,6 +195,114 @@ function piModels(providerId: string, baseUrl: string): SetupFile {
       "    }",
       "  }",
       "}",
+    ].join("\n"),
+  };
+}
+
+/**
+ * Oh My Pi's provider override file. Like Pi's, the key is `baseUrl`, in this
+ * exact spelling. Overriding a built-in provider only moves its endpoint; the
+ * whole built-in model list keeps working.
+ */
+function ompModels(providerId: string, baseUrl: string): SetupFile {
+  return {
+    path: "~/.omp/agent/models.yml",
+    language: "yaml",
+    body: ["providers:", `  ${providerId}:`, `    baseUrl: ${baseUrl}`]
+      .join("\n"),
+  };
+}
+
+/**
+ * A locally hosted model server. The student gives the address of the server;
+ * this tool sits between Oh My Pi and that server, and writes a readable
+ * document for every request on the way through.
+ *
+ * Every server we target serves the OpenAI-compatible API under /v1, so this
+ * route uses the same wire as the OpenAI route. The only difference is where
+ * the upstream lives: on the student's machine, over plain http.
+ */
+const LOCAL_NOTE =
+  "This route talks to a model running on your own machine instead of a " +
+  "cloud API. The address is yours, and the model to use is picked from what " +
+  "the server offers. No API key is needed: the server is on your own " +
+  "network, and Oh My Pi is told not to send one. The command pins the main " +
+  "model and the background model to it, so every call stays on your machine " +
+  "and gets captured.";
+
+/**
+ * The parts the tool needs to dial the student's local server. Named rather
+ * than inlined so the contract is importable by the proxy and the tests.
+ */
+export interface LocalUpstream {
+  scheme: "http" | "https";
+  host: string;
+  port: number;
+  /** Path prepended to received paths before forwarding; empty when none. */
+  prefix: string;
+}
+
+/**
+ * Split the student's local server URL into the parts the tool needs to
+ * forward to it.
+ *
+ * Pure: no network, no clock. The same URL always gives the same answer. A
+ * trailing /v1 is stripped, because the OpenAI-compatible API is always under
+ * /v1 relative to the server's root, and the requests already carry it.
+ */
+export function localUpstream(url: string): LocalUpstream {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    throw new Error(
+      `"${url}" is not a URL. Give the address of your local model server, ` +
+        `such as http://127.0.0.1:8000.`
+    );
+  }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    throw new Error(
+      `Your local model server must speak http or https. "${url}" does not.`
+    );
+  }
+  const scheme = parsed.protocol.slice(0, -1) as "http" | "https";
+  const host = parsed.hostname;
+  if (!host) throw new Error(`"${url}" has no host.`);
+  // A URL can leave the port implicit. Make it explicit, because the forwarder
+  // dials the port on its own.
+  const port = parsed.port ? Number(parsed.port) : scheme === "https" ? 443 : 80;
+  let prefix = parsed.pathname.replace(/\/+$/, "");
+  if (prefix.endsWith("/v1")) prefix = prefix.slice(0, -3);
+  return { scheme, host, port, prefix };
+}
+
+/**
+ * Oh My Pi's local model block. A provider that lists models is a full
+ * provider, not an override, so it does not touch any of the built-in
+ * providers. It is also the only way to name a model that is not in the
+ * built-in list.
+ *
+ * `auth: none` tells Oh My Pi to send no key. `api: openai-completions` tells
+ * it to call /chat/completions, the endpoint every local server serves.
+ * `baseUrl` points at this tool, not at the server: the server's address is
+ * told to the tool separately, and the tool forwards to it.
+ */
+function ompLocalModels(modelId: string, proxyBaseUrl: string): SetupFile {
+  return {
+    path: "~/.omp/agent/models.yml",
+    language: "yaml",
+    body: [
+      "providers:",
+      "  local:",
+      "    baseUrl:",
+      `      ${proxyBaseUrl}`,
+      "    auth: none",
+      "    api: openai-completions",
+      "    models:",
+      "      - id:",
+      `        ${modelId}`,
+      "        name: Local",
+      "        api: openai-completions",
     ].join("\n"),
   };
 }
@@ -414,6 +552,85 @@ const AGENTS: AgentEntry[] = [
     ],
   },
   {
+    id: "omp",
+    label: "Oh My Pi",
+    providers: [
+      {
+        id: "anthropic",
+        label: "Anthropic",
+        upstreamHost: "api.anthropic.com",
+        renderer: "anthropic",
+        env: [["ANTHROPIC_BASE_URL", "{baseUrl}"]],
+        bin: "omp",
+        notes: [
+          "One variable, no config file. It works with an Anthropic API key " +
+            "and with a Claude subscription login; your login stays active, " +
+            "only the model traffic moves.",
+          "The variable lasts for the run it is printed in. Nothing is " +
+            "written to any file, so your normal Oh My Pi is unchanged the " +
+            "moment you stop using this command.",
+          "Oh My Pi also makes small background calls with a smaller model, " +
+            "such as titling a session. When that model runs on this " +
+            "provider, each turn writes a few extra small captures alongside " +
+            "the real one. That is what the agent really sends.",
+        ],
+      },
+      {
+        id: "openai",
+        label: "OpenAI API key",
+        upstreamHost: "api.openai.com",
+        renderer: "openai",
+        // omp's OpenAI transport appends only /responses, so the base URL has
+        // to carry the /v1.
+        suffix: "/v1",
+        bin: "omp",
+        setup: [ompModels("openai", "{baseUrl}")],
+        notes: [
+          "Oh My Pi has no base URL variable on this route. Overriding the " +
+            "provider in its models file is the only way to point it at this " +
+            "tool, and it keeps the agent's whole built-in model list. If " +
+            "that file already exists, add this provider to it rather than " +
+            "replacing it, or your other providers disappear.",
+        ],
+      },
+      {
+        id: "codex",
+        label: "ChatGPT subscription",
+        upstreamHost: "chatgpt.com",
+        renderer: "openai",
+        // omp appends `/codex/responses` itself, and the real endpoint sits
+        // under `/backend-api`, so the base URL must carry that prefix.
+        suffix: "/backend-api",
+        env: [["PI_CODEX_WEBSOCKET", "false"]],
+        bin: "omp",
+        setup: [ompModels("openai-codex", "{baseUrl}")],
+        notes: [
+          "The flag and the file do different jobs. The file moves the " +
+            "endpoint; the flag stops Oh My Pi opening a WebSocket, which " +
+            "this tool cannot see. With the flag it streams over HTTP, so " +
+            "every turn is captured. It works with a ChatGPT subscription " +
+            "login.",
+          "If the models file already exists, add this provider to it rather " +
+            "than replacing it.",
+        ],
+      },
+      {
+        id: "local",
+        label: "Local model (Ollama, vLLM, LM Studio, …)",
+        // Placeholder. The real host and port come from the student's URL at
+        // resolve time; a local server lives on their machine.
+        upstreamHost: "127.0.0.1",
+        renderer: "openai",
+        local: true,
+        // omp's openai-completions transport appends only /chat/completions, so
+        // the base URL has to carry the /v1.
+        suffix: "/v1",
+        bin: "omp",
+        notes: [LOCAL_NOTE],
+      },
+    ],
+  },
+  {
     id: "gemini",
     label: "Gemini CLI",
     providers: [
@@ -472,6 +689,8 @@ export interface AgentSummary {
 export interface ProviderSummary {
   id: string;
   label: string;
+  /** True when picking this provider asks for the address of a local server. */
+  local: boolean;
 }
 
 /**
@@ -499,7 +718,11 @@ export function listAgents(): AgentSummary[] {
 export function listProviders(agentId: string): ProviderSummary[] {
   const agent = AGENTS.find((a) => a.id === agentId);
   if (!agent?.providers || agent.providers.length < 2) return [];
-  return agent.providers.map((p) => ({ id: p.id, label: p.label }));
+  return agent.providers.map((p) => ({
+    id: p.id,
+    label: p.label,
+    local: !!p.local,
+  }));
 }
 
 // ---------------------------------------------------------------------------
@@ -612,6 +835,48 @@ export function resolveChoice(
 
   const baseUrl = `http://localhost:${options.port}${provider.suffix ?? ""}`;
 
+  // A local model server lives on the student's machine, so its host and port
+  // are not in the catalogue. They come from the URL the student gave the
+  // wizard. Without that URL there is nothing to forward to, so this is an
+  // error, not a guess.
+  if (provider.local) {
+    if (!choice.localUrl) {
+      return {
+        kind: "error",
+        message:
+          `${agent.label} on a local model needs the address of your local ` +
+          `model server. Run with --force and enter it when asked.`,
+      };
+    }
+    let up: LocalUpstream;
+    try {
+      up = localUpstream(choice.localUrl);
+    } catch (err) {
+      return { kind: "error", message: (err as Error).message };
+    }
+    const modelId = choice.localModel ?? "local";
+    return {
+      kind: "target",
+      agent: agent.id,
+      agentLabel: agent.label,
+      provider: provider.id,
+      providerLabel: provider.label,
+      upstreamHost: up.host,
+      upstreamScheme: up.scheme,
+      upstreamPort: up.port,
+      upstreamPrefix: up.prefix,
+      renderer: provider.renderer,
+      baseUrl,
+      // The model is addressed as local/<id>: `local` is the provider id in
+      // the models file, and <id> is the model the server offers. The smol
+      // role is pinned to the same model so background calls stay local too.
+      command: `omp --model local/${modelId} --smol local/${modelId}`,
+      setup: [ompLocalModels(modelId, baseUrl)],
+      notes: provider.notes ?? [],
+      warnings: provider.warnings ?? [],
+    };
+  }
+
   return {
     kind: "target",
     agent: agent.id,
@@ -619,6 +884,9 @@ export function resolveChoice(
     provider: provider.id,
     providerLabel: provider.label,
     upstreamHost: provider.upstreamHost,
+    upstreamScheme: "https",
+    upstreamPort: 443,
+    upstreamPrefix: "",
     renderer: provider.renderer,
     baseUrl,
     command: buildCommand(provider, baseUrl),

--- a/request-logger/config.test.ts
+++ b/request-logger/config.test.ts
@@ -27,6 +27,20 @@ describe("the remembered answer", () => {
     expect(loadChoice(file)).toEqual({ agent: "claude-code", provider: undefined });
   });
 
+  it("reads back a local model choice with its server and model", () => {
+    // The wizard stores the address and model of the student's local server.
+    // Losing either on a re-read would make the tool ask again or forward to
+    // nothing, so the round-trip must keep both.
+    const choice = {
+      agent: "omp",
+      provider: "local",
+      localUrl: "http://127.0.0.1:8000",
+      localModel: "llama3-8b",
+    };
+    saveChoice(file, choice);
+    expect(loadChoice(file)).toEqual(choice);
+  });
+
   it("reports no answer when the file is not there", () => {
     expect(loadChoice(file)).toBeNull();
   });

--- a/request-logger/config.ts
+++ b/request-logger/config.ts
@@ -13,14 +13,16 @@
 
 import fs from "node:fs";
 import { styleText } from "node:util";
-import { cancel, confirm, isCancel, intro, select } from "@clack/prompts";
+import { cancel, confirm, isCancel, intro, select, text } from "@clack/prompts";
 import {
   listAgents,
   listProviders,
   OTHER_ID,
   OTHER_LABEL,
+  localUpstream,
   type AgentChoice,
 } from "./agents";
+import { probeLocalServer, type LocalProbe } from "./local";
 
 export interface WizardAnswer {
   choice: AgentChoice;
@@ -46,6 +48,8 @@ export function loadChoice(file: string): AgentChoice | null {
     return {
       agent: parsed.agent,
       provider: typeof parsed.provider === "string" ? parsed.provider : undefined,
+      localUrl: typeof parsed.localUrl === "string" ? parsed.localUrl : undefined,
+      localModel: typeof parsed.localModel === "string" ? parsed.localModel : undefined,
     };
   } catch {
     return null;
@@ -133,6 +137,53 @@ export async function askChoice(options: AskOptions): Promise<WizardAnswer> {
     );
     choice = { agent: agentId, provider: providerId };
     if (providerId === OTHER_ID) return { choice, remember: false };
+  }
+
+  // A local model server lives on the student's machine, so its address is not
+  // in the catalogue. Ask for it, confirm it answers, and pick the model to
+  // use. Without a reachable server there is nothing to forward to, so the
+  // wizard refuses to finish rather than guess.
+  const picked = providers.find((p) => p.id === choice.provider);
+  if (picked?.local) {
+    let probe: LocalProbe = { ok: false, models: [] };
+    for (let attempt = 0; attempt < 3; attempt++) {
+      const raw = stopIfCancelled(
+        await text({
+          message: "Address of your local model server",
+          placeholder: "http://127.0.0.1:8000",
+        })
+      );
+      const url = raw.trim();
+      if (url.length === 0) continue;
+      let root: string;
+      try {
+        const { scheme, host, port, prefix } = localUpstream(url);
+        root = `${scheme}://${host}:${port}${prefix}`;
+      } catch (err) {
+        console.error(`  ${styleText("dim", (err as Error).message)}`);
+        continue;
+      }
+      probe = await probeLocalServer(root);
+      if (probe.ok) {
+        choice = { ...choice, localUrl: root, localModel: probe.models[0] };
+        break;
+      }
+      console.error(`  ${styleText("dim", probe.error ?? "could not reach the server")}`);
+    }
+    if (!probe.ok || probe.models.length === 0) {
+      cancel("Could not reach a local model server. Nothing was started.");
+      process.exit(1);
+    }
+    if (probe.models.length > 1) {
+      const model = stopIfCancelled(
+        await select({
+          message: "Which model is that server running?",
+          options: probe.models.map((id) => ({ value: id, label: id })),
+          initialValue: probe.models[0],
+        })
+      );
+      choice = { ...choice, localModel: model };
+    }
   }
 
   // An agent that cannot be logged is a dead end. Saving it would only make the

--- a/request-logger/local.test.ts
+++ b/request-logger/local.test.ts
@@ -1,0 +1,84 @@
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import http from "node:http";
+import { probeLocalServer } from "./local";
+
+// A fake local model server. It answers the OpenAI and Ollama model
+// endpoints, so the probe can be tested without a real model on the machine.
+// The path it is asked to serve is chosen per test, so the same server can
+// stand in for an OpenAI-compatible server or an Ollama.
+const MODELS = {
+  openai: { data: [{ id: "llama3-8b" }, { id: "gemma-2b" }] },
+  ollama: { models: [{ name: "llama3:8b" }] },
+};
+
+let server: http.Server;
+let port: number;
+let wire: "openai" | "ollama";
+
+beforeAll(async () => {
+  server = http.createServer((req, res) => {
+    const path = req.url ?? "/";
+    const send = (status: number, body: unknown) => {
+      res.writeHead(status, { "content-type": "application/json" });
+      res.end(JSON.stringify(body));
+    };
+    if (wire === "openai" && path === "/v1/models") return send(200, MODELS.openai);
+    if (wire === "ollama" && path === "/api/tags") return send(200, MODELS.ollama);
+    send(404, { error: "not found" });
+  });
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const address = server.address();
+  port = typeof address === "object" && address ? address.port : 0;
+});
+
+afterAll(async () => {
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+});
+
+const url = () => `http://127.0.0.1:${port}`;
+
+describe("probeLocalServer", () => {
+  it("reads an OpenAI-compatible server's models", async () => {
+    wire = "openai";
+    const probe = await probeLocalServer(url());
+    expect(probe.ok).toBe(true);
+    expect(probe.models).toEqual(["llama3-8b", "gemma-2b"]);
+  });
+
+  it("reads a trailing /v1 off the address, because the probe adds it back", async () => {
+    wire = "openai";
+    const probe = await probeLocalServer(`${url()}/v1`);
+    expect(probe.ok).toBe(true);
+    expect(probe.models).toEqual(["llama3-8b", "gemma-2b"]);
+  });
+
+  it("reads an Ollama server through its native tag list", async () => {
+    wire = "ollama";
+    const probe = await probeLocalServer(url());
+    expect(probe.ok).toBe(true);
+    expect(probe.models).toEqual(["llama3:8b"]);
+  });
+
+  it("reports an error when the server offers no models", async () => {
+    // A server that answers none of the model endpoints, but does answer, is
+    // not a model server as far as this tool is concerned.
+    wire = "openai";
+    const probe = await probeLocalServer(`${url()}/definitely-not-a-model-endpoint`);
+    expect(probe.ok).toBe(false);
+    expect(probe.models).toEqual([]);
+  });
+
+  it("reports an error for an address that is not a URL", async () => {
+    const probe = await probeLocalServer("not a url");
+    expect(probe.ok).toBe(false);
+    expect(probe.error).toBeDefined();
+  });
+
+  it("reports an error when nothing is listening", async () => {
+    // Port 1 is effectively never open, so the probe must time out and fail
+    // rather than hang the wizard.
+    const probe = await probeLocalServer("http://127.0.0.1:1");
+    expect(probe.ok).toBe(false);
+    expect(probe.error).toBeDefined();
+  });
+});

--- a/request-logger/local.ts
+++ b/request-logger/local.ts
@@ -1,0 +1,111 @@
+/**
+ * local.ts — asks a local model server what models it offers.
+ *
+ * The rest of the tool is pure: agents.ts never touches the network, and the
+ * proxy only forwards. The probe is the one place that talks to the student's
+ * machine, because it happens once, in the wizard, when the student types the
+ * address of their server. Its job is narrow: find the model ids the server
+ * offers, so the wizard can let the student pick one and the rest of the tool
+ * can work with that id.
+ *
+ * Every server we target serves the OpenAI-compatible API, so the primary probe
+ * is the OpenAI models endpoint. Ollama also answers the native /api/tags, which
+ * is probed as a fallback for servers that do not expose the OpenAI route.
+ */
+
+/** The answer to "what models does this server offer?". */
+export interface LocalProbe {
+  /** True when at least one model was found. */
+  ok: boolean;
+  /** The model ids the server offers, in the order it reported them. */
+  models: string[];
+  /** Why the probe failed, when it did. */
+  error?: string;
+}
+
+/** How long the wizard waits for a server to answer before giving up. */
+const PROBE_TIMEOUT_MS = 5000;
+
+/**
+ * Ask a local model server for the models it offers.
+ *
+ * Pure enough to test: the only input is a URL and the only output is a list of
+ * model ids (or an error). No global state, no clock beyond the fetch timeout.
+ */
+export async function probeLocalServer(url: string): Promise<LocalProbe> {
+  let root: string;
+  try {
+    const parsed = new URL(url);
+    if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+      return { ok: false, models: [], error: `a local model server must speak http or https` };
+    }
+    // The base the server serves its API under, with no trailing slash. A
+    // trailing /v1 is dropped, because the candidates below add it themselves.
+    root = `${parsed.protocol}//${parsed.host}${parsed.pathname.replace(/\/+$/, "")}`.replace(
+      /\/v1$/,
+      ""
+    );
+  } catch {
+    return { ok: false, models: [], error: `"${url}" is not a URL` };
+  }
+
+  // The OpenAI models endpoint lives under /v1 on most servers and under / on
+  // some. Try both, then Ollama's native tag list.
+  const candidates = [`${root}/v1/models`, `${root}/models`, `${root}/api/tags`];
+  for (const candidate of candidates) {
+    const found = await fetchModels(candidate);
+    if (found.length > 0) return { ok: true, models: found };
+  }
+
+  return {
+    ok: false,
+    models: [],
+    error: `no models found at ${url}. Is the server running, and does it serve the OpenAI-compatible API?`,
+  };
+}
+
+/** Fetch one models endpoint and return the model ids it lists, or none. */
+async function fetchModels(endpoint: string): Promise<string[]> {
+  let res: Response;
+  try {
+    res = await fetch(endpoint, {
+      method: "GET",
+      signal: AbortSignal.timeout(PROBE_TIMEOUT_MS),
+    });
+  } catch {
+    return [];
+  }
+  if (!res.ok) return [];
+
+  let json: unknown;
+  try {
+    json = await res.json();
+  } catch {
+    return [];
+  }
+
+  if (json == null || typeof json !== "object") return [];
+  const body = json as { data?: unknown; models?: unknown };
+
+  // OpenAI shape: { "data": [ { "id": "..." } ] }
+  if (Array.isArray(body.data)) return modelIds(body.data, "id");
+  // Ollama shape: { "models": [ { "name": "..." } ] }
+  if (Array.isArray(body.models)) return modelIds(body.models, "name");
+  return [];
+}
+
+/**
+ * Pull a single string field out of a list of model objects. The field is
+ * `id` on the OpenAI wire and `name` on Ollama's native wire; everything else
+ * is skipped, so a server that answers with an unexpected shape is a no-op,
+ * not a crash.
+ */
+function modelIds(list: unknown[], field: "id" | "name"): string[] {
+  const ids: string[] = [];
+  for (const item of list) {
+    if (item == null || typeof item !== "object") continue;
+    const candidate = (item as Record<string, unknown>)[field];
+    if (typeof candidate === "string" && candidate.length > 0) ids.push(candidate);
+  }
+  return ids;
+}

--- a/request-logger/proxy.ts
+++ b/request-logger/proxy.ts
@@ -88,42 +88,48 @@ function handle(
     const base = baseName(target);
     const encoding = req.headers["content-encoding"];
 
-    const upstreamReq = https.request(
-      {
-        hostname: target.upstreamHost,
-        port: 443,
-        path: reqPath,
-        method: req.method,
-        headers: {
-          ...forwardHeaders(req.headers, body),
-          host: target.upstreamHost,
-        },
+    // The upstream is https for a cloud provider and plain http for a local
+    // model server. Dial the scheme and port the catalogue told us, and
+    // prepend the server's subpath so a server that lives under a prefix
+    // still sees the request where it expects it.
+    const opts: http.RequestOptions = {
+      hostname: target.upstreamHost,
+      port: target.upstreamPort,
+      path: target.upstreamPrefix + reqPath,
+      method: req.method,
+      headers: {
+        ...forwardHeaders(req.headers, body),
+        host: target.upstreamHost,
       },
-      (upstreamRes) => {
-        res.writeHead(upstreamRes.statusCode ?? 502, upstreamRes.headers);
-        const responseChunks: Buffer[] = [];
-        upstreamRes.on("data", (chunk: Buffer) => {
-          responseChunks.push(chunk);
-          res.write(chunk); // stream straight back to the agent, unbuffered
+    };
+    const cb = (upstreamRes: http.IncomingMessage): void => {
+      res.writeHead(upstreamRes.statusCode ?? 502, upstreamRes.headers);
+      const responseChunks: Buffer[] = [];
+      upstreamRes.on("data", (chunk: Buffer) => {
+        responseChunks.push(chunk);
+        res.write(chunk); // stream straight back to the agent, unbuffered
+      });
+      upstreamRes.on("end", () => {
+        res.end();
+        const responseRaw = Buffer.concat(responseChunks).toString("utf8");
+        writeCapture({
+          base,
+          target,
+          timestamp,
+          method: req.method ?? "POST",
+          path: reqPath,
+          statusCode: upstreamRes.statusCode ?? 0,
+          headers: req.headers,
+          requestBody: body,
+          requestEncoding: Array.isArray(encoding) ? encoding[0] : encoding,
+          responseRaw,
         });
-        upstreamRes.on("end", () => {
-          res.end();
-          const responseRaw = Buffer.concat(responseChunks).toString("utf8");
-          writeCapture({
-            base,
-            target,
-            timestamp,
-            method: req.method ?? "POST",
-            path: reqPath,
-            statusCode: upstreamRes.statusCode ?? 0,
-            headers: req.headers,
-            requestBody: body,
-            requestEncoding: Array.isArray(encoding) ? encoding[0] : encoding,
-            responseRaw,
-          });
-        });
-      }
-    );
+      });
+    };
+    const upstreamReq =
+      target.upstreamScheme === "https"
+        ? https.request(opts, cb)
+        : http.request(opts, cb);
 
     upstreamReq.on("error", (err) => {
       console.error(`[request-logger] upstream error: ${err.message}`);
@@ -209,13 +215,22 @@ function field(label: string, value: string): void {
   console.log(`  ${dim(label.padEnd(10))} ${value}`);
 }
 
+/** Where the tool forwards: the scheme and port the catalogue told us. */
+function forwardsAddress(target: ResolvedTarget): string {
+  const port =
+    (target.upstreamScheme === "https" ? 443 : 80) === target.upstreamPort
+      ? ""
+      : `:${target.upstreamPort}`;
+  return `${target.upstreamScheme}://${target.upstreamHost}${port}`;
+}
+
 function printBanner(target: ResolvedTarget): void {
   const rule = dim("-".repeat(72));
   console.log("");
   console.log(rule);
   field("Agent", bold(`${target.agentLabel} (${target.providerLabel})`));
   field("Listening", `http://localhost:${PORT}`);
-  field("Forwards", `https://${target.upstreamHost}`);
+  field("Forwards", forwardsAddress(target));
   field("Logs", dim(LOG_DIR));
   console.log(rule);
 


### PR DESCRIPTION
Adds Oh My Pi (omp) to the request-logger catalogue, plus a local-model route so a student can point the tool at a model server running on their own machine (Ollama, vLLM, LM Studio, ...).

## What changed

- **Catalogue (agents.ts):** new Oh My Pi entry with Anthropic / OpenAI / Codex / Local routes; the `local` route carries the student's own server address and model id through the existing resolution seam. Added a pure `localUpstream()` that splits that URL into scheme/host/port/prefix.
- **Proxy (proxy.ts):** dials the upstream by scheme + port over plain http/https, so it works against a localhost server, not just https APIs. Banner prints the real forward target.
- **Probe (local.ts):** new module that asks a local server what models it offers (OpenAI `/v1/models` and Ollama `/api/tags`) so the wizard can offer the student a choice.
- **Wizard (config.ts):** for the local route, prompts for the server address, probes it (bounded retry), and lets the student pick the model. The chosen address + model are remembered.
- **README:** Oh My Pi row in the support table and a note on its background small-model calls.

## Notes

- Oh My Pi never counts tokens, so every file in the logs folder is a real turn. It does make small background calls (session titling) with a smaller model; the printed command pins both the main and the background model to the chosen one, so every call stays on the local server and gets captured.
- The local route needs no API key; Oh My Pi is told not to send one.
- A remembered local choice round-trips through the state file (address + model are preserved on re-read).

## Verification

- tsc --noEmit clean; vitest run: 187 tests pass (agents 137, config 7, local 6, render 37).
- Live smoke test: ran the real proxy against a fake local server over http and confirmed a turn is forwarded, the probe endpoint works, a readable markdown capture is written, and the banner/command are correct.