### PR TITLE
request-logger: custom base URL mechanism + a named OMP entry

### DIFF
--- a/request-logger/README.md
+++ b/request-logger/README.md
@@ -14,16 +14,33 @@ goes over the wire.
 npm run request-logger
 ```
 
-The first time you run it, it asks which agent you use. If your agent can drive
-more than one model provider, it asks which provider. Last, it asks whether to
-remember your answer. Say no if you swap agents often, and it asks again every
-time. It then prints the exact command for your setup, and starts listening.
+The first time you run it, it asks which agent you use, then which model
+provider you use with it. (OMP is the one exception: it has no fixed provider
+of its own, so it skips straight to the base URL question below.) Last, it
+asks whether to remember your answer. Say no if you swap agents often, and it
+asks again every time. It then prints the exact command for your setup, and
+starts listening.
 
 It keeps listening until you stop it. Press **Ctrl+C** to stop it. The console
 says so too.
 
 Both questions end with **Other, or not sure**. Pick it if your setup is not in
 the list, and the tool gives you a link to ask for it.
+
+The provider question has a second way out, too: **Custom base URL**. Pick it
+if your provider is not in the list but you know its base URL — a local model
+server such as Ollama, or a smaller hosted provider such as DeepSeek, say. It
+asks two questions instead of showing you a dead end:
+
+- the base URL of the model server you want to log, for example
+  `http://localhost:11434` for Ollama, or `https://api.deepseek.com` for
+  DeepSeek; and
+- which wire format it speaks — OpenAI-compatible, Anthropic-compatible, or
+  "not sure", if you do not know.
+
+If you are not sure, pick "not sure". The tool still logs everything; it just
+shows you the raw JSON instead of a fully readable render, because it cannot
+safely guess a shape you did not tell it. See "What you get" below.
 
 To change a remembered answer:
 
@@ -46,6 +63,12 @@ gitignored. It holds your choice only. The host, the renderer and the command ar
 worked out again on every start, so an update to this tool reaches you without
 you having to clear anything.
 
+The one exception is a **Custom base URL** answer. There is no catalogue entry
+for it to be worked out from — you typed it — so the base URL and the wire
+format you chose are saved in the file too, alongside your choice. Everything
+else about a custom answer still behaves the same way: change it any time with
+`--force`, and it is never kept for an agent that cannot be logged.
+
 ## The agents
 
 The tool prints the correct command for you, so you do not have to copy anything
@@ -58,9 +81,14 @@ from this table. It is here so you can see what is supported before you start.
 | GitHub Copilot   | Yes   | Your normal subscription login.                  |
 | OpenCode         | Yes   | One command, or a config file.                   |
 | Pi               | Yes   | A config file. Pi has no base URL variable.      |
+| OMP              | Yes   | A YAML config file. Point it at any backend.     |
 | Gemini CLI       | Yes   | One command. The free Google login works.        |
 | Cursor CLI       | No    | Nothing can make it work. See below.             |
 | Amp              | No    | Nothing can make it work. See below.             |
+
+Any other provider — a local model server, or a smaller hosted one — works
+through **Custom base URL**, above, on any agent in this table except Cursor
+and Amp.
 
 ### Why Cursor and Amp cannot work
 
@@ -119,6 +147,13 @@ The `.md` file uses **XML tags** (`<request>`, `<system-prompt>`, `<tools>`,
 `<messages>`, `<response>`) to mark its sections, because the captured content is
 full of its own Markdown headings. It is complete and not truncated, so it is a
 trustworthy readout of what the model received.
+
+If you picked "not sure" for a custom base URL's wire format, the `.md` file
+holds pretty-printed JSON instead of that fully tagged render — there is no
+system prompt or tool section, because the tool was not told the shape needed
+to find them. Nothing is lost: it is still the whole request and response, just
+less readable. Run with `--force` and pick the real wire format once you know
+it, and the tagged render takes over from the next request.
 
 Secret headers (`authorization`, `x-api-key`, `api-key`) are hidden in the `.md`
 file and are never written to the `.txt` files.
@@ -187,10 +222,15 @@ of these happened:
 
 Be fair to the tool when you judge a failure.
 
-- **Claude Code is tested end to end.** The measurements above are real.
+- **Claude Code and OMP are tested end to end.** The measurements above are
+  real, and OMP is run daily by the person who built this tool.
 - **The others were verified** by reading the published code of each agent and
   by driving them against a local listener. They were not each run through a
   full course of the lesson.
+- **A custom base URL is only as tested as the agent it is attached to.** The
+  base URL and wire format mechanism itself is tested directly (see
+  `agents.test.ts`); a specific third-party server behind it has not
+  necessarily been driven end to end.
 
 If one of them is wrong, it is worth reporting, and the fix is likely to be one
 line in `agents.ts`.
@@ -201,6 +241,11 @@ line in `agents.ts`.
   upstream host, its renderer, its base URL suffix, and its command. That is the
   whole job. The wizard, the banner and the routing all read from there, so
   nothing else needs to change.
+- **Add an agent with no fixed upstream at all**, the way OMP has none: give it
+  no upstream host, set `alwaysCustom: true`, and give its one provider entry a
+  bin and a setup file. The wizard then skips the provider question for it
+  entirely and asks the two custom-base-url questions directly. See the OMP
+  entry in `agents.ts` for the whole shape.
 - **Add a wire format:** add a renderer in `render.ts` and name it on the
   catalogue entry. Unknown shapes already fall back to pretty-printed JSON, so
   you can iterate safely.
@@ -208,3 +253,6 @@ line in `agents.ts`.
   rule. Some agents append the whole path to what you give them and so must not
   have a `/v1`. Some append only the last part and so must have one. Getting it
   wrong produces a 404 that is hard to read. There is a test for each one.
+- **Nothing to do for a student on an unlisted provider.** "Custom base URL" at
+  the provider question already covers that — see the top of this README. It
+  is not a per-agent thing to add; every supported agent gets it for free.

--- a/request-logger/agents.test.ts
+++ b/request-logger/agents.test.ts
@@ -1,11 +1,14 @@
 import { describe, it, expect } from "vitest";
 import {
+  agentProviders,
+  CUSTOM_ID,
   ISSUE_URL,
   listAgents,
   listProviders,
   OTHER_ID,
   resolveChoice,
   shouldLogRequest,
+  type AgentChoice,
 } from "./agents";
 
 const PORT = { port: 8787 };
@@ -17,6 +20,15 @@ function target(agent: string, provider?: string) {
     throw new Error(
       `expected a target for ${agent}/${provider}, got ${result.kind}`
     );
+  }
+  return result;
+}
+
+/** Resolve a custom-base-url choice, and fail loudly if it was not a usable target. */
+function customTarget(choice: AgentChoice) {
+  const result = resolveChoice(choice, PORT);
+  if (result.kind !== "custom-target") {
+    throw new Error(`expected a custom-target, got ${result.kind}`);
   }
   return result;
 }
@@ -67,6 +79,7 @@ describe("listAgents", () => {
       "copilot",
       "opencode",
       "pi",
+      "omp",
       "gemini",
       "cursor",
       "amp",
@@ -97,6 +110,26 @@ describe("listAgents", () => {
     const opencode = listAgents().find((agent) => agent.id === "opencode");
     expect(opencode?.needsProvider).toBe(true);
   });
+
+  it("marks OMP as supported", () => {
+    const omp = listAgents().find((agent) => agent.id === "omp");
+    expect(omp?.supported).toBe(true);
+  });
+
+  it("marks OMP as always custom", () => {
+    const omp = listAgents().find((agent) => agent.id === "omp");
+    expect(omp?.alwaysCustom).toBe(true);
+  });
+
+  it("says no other agent is always custom", () => {
+    const others = listAgents().filter((agent) => agent.id !== "omp");
+    expect(others.every((agent) => agent.alwaysCustom === false)).toBe(true);
+  });
+
+  it("says OMP needs no provider question, because it never shows one", () => {
+    const omp = listAgents().find((agent) => agent.id === "omp");
+    expect(omp?.needsProvider).toBe(false);
+  });
 });
 
 describe("listProviders", () => {
@@ -125,6 +158,34 @@ describe("listProviders", () => {
 
   it("leads Pi with the Anthropic route, which is the simplest", () => {
     expect(listProviders("pi")[0].id).toBe("anthropic");
+  });
+});
+
+describe("agentProviders", () => {
+  it("returns the one provider a single-provider agent has, unlike listProviders", () => {
+    expect(listProviders("claude-code")).toEqual([]);
+    expect(agentProviders("claude-code").map((p) => p.id)).toEqual(["anthropic"]);
+  });
+
+  it("returns the one provider Copilot has too", () => {
+    expect(agentProviders("copilot").map((p) => p.id)).toEqual(["github"]);
+  });
+
+  it("returns nothing for a refused agent", () => {
+    expect(agentProviders("cursor")).toEqual([]);
+  });
+
+  it("returns OMP's one internal template provider, even though the wizard never shows it", () => {
+    // config.ts never calls agentProviders for an alwaysCustom agent — see
+    // askChoice — but the entry exists to hold the command/setup template
+    // resolveCustomTarget borrows from, so it is not empty here.
+    expect(agentProviders("omp").map((p) => p.id)).toEqual([CUSTOM_ID]);
+  });
+
+  it("agrees with listProviders once there are two or more", () => {
+    expect(agentProviders("opencode").map((p) => p.id)).toEqual(
+      listProviders("opencode").map((p) => p.id)
+    );
   });
 });
 
@@ -577,5 +638,317 @@ describe("resolveChoice — bad input", () => {
   it("points the student at --force when a choice cannot be resolved", () => {
     const result = resolveChoice({ agent: "nonesuch" }, PORT);
     expect(result.kind === "error" && result.message).toContain("--force");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Custom base URL — resolving a target the catalogue does not know about
+// ---------------------------------------------------------------------------
+
+describe("resolveChoice — custom base URL", () => {
+  it("resolves a valid http:// target", () => {
+    const result = customTarget({
+      agent: "opencode",
+      provider: CUSTOM_ID,
+      customBaseUrl: "http://localhost:11434",
+      customRenderer: "openai",
+    });
+    expect(result.upstreamBaseUrl).toBe("http://localhost:11434");
+  });
+
+  it("resolves a valid https:// target", () => {
+    const result = customTarget({
+      agent: "opencode",
+      provider: CUSTOM_ID,
+      customBaseUrl: "https://api.deepseek.com",
+      customRenderer: "openai",
+    });
+    expect(result.upstreamBaseUrl).toBe("https://api.deepseek.com");
+  });
+
+  it("strips a path from the typed base URL, the same way the catalogue keeps a bare host", () => {
+    const result = customTarget({
+      agent: "opencode",
+      provider: CUSTOM_ID,
+      customBaseUrl: "https://api.deepseek.com/v1/some/path",
+      customRenderer: "openai",
+    });
+    expect(result.upstreamBaseUrl).toBe("https://api.deepseek.com");
+  });
+
+  it("rejects a base URL with no scheme", () => {
+    const result = resolveChoice(
+      { agent: "opencode", provider: CUSTOM_ID, customBaseUrl: "localhost:11434" },
+      PORT
+    );
+    expect(result.kind).toBe("error");
+  });
+
+  it("rejects a base URL that is not a URL at all", () => {
+    const result = resolveChoice(
+      { agent: "opencode", provider: CUSTOM_ID, customBaseUrl: "not a url" },
+      PORT
+    );
+    expect(result.kind).toBe("error");
+  });
+
+  it("rejects a base URL with an unrelated scheme", () => {
+    const result = resolveChoice(
+      { agent: "opencode", provider: CUSTOM_ID, customBaseUrl: "ftp://example.com" },
+      PORT
+    );
+    expect(result.kind).toBe("error");
+  });
+
+  it("names the base URL in the rejection", () => {
+    const result = resolveChoice(
+      { agent: "opencode", provider: CUSTOM_ID, customBaseUrl: "not a url" },
+      PORT
+    );
+    expect(result.kind === "error" && result.message).toContain("not a url");
+  });
+
+  it("points the student at --force when the base URL cannot be resolved", () => {
+    const result = resolveChoice(
+      { agent: "opencode", provider: CUSTOM_ID, customBaseUrl: "not a url" },
+      PORT
+    );
+    expect(result.kind === "error" && result.message).toContain("--force");
+  });
+
+  it("rejects a custom choice with no base URL at all", () => {
+    const result = resolveChoice({ agent: "opencode", provider: CUSTOM_ID }, PORT);
+    expect(result.kind).toBe("error");
+  });
+
+  it("defaults to the raw renderer when no wire format was given", () => {
+    const result = customTarget({
+      agent: "opencode",
+      provider: CUSTOM_ID,
+      customBaseUrl: "http://localhost:11434",
+    });
+    expect(result.renderer).toBe("raw");
+  });
+
+  it("uses the openai renderer when that wire format is chosen", () => {
+    expect(
+      customTarget({
+        agent: "opencode",
+        provider: CUSTOM_ID,
+        customBaseUrl: "http://localhost:11434",
+        customRenderer: "openai",
+      }).renderer
+    ).toBe("openai");
+  });
+
+  it("uses the anthropic renderer when that wire format is chosen", () => {
+    expect(
+      customTarget({
+        agent: "opencode",
+        provider: CUSTOM_ID,
+        customBaseUrl: "http://localhost:11434",
+        customRenderer: "anthropic",
+      }).renderer
+    ).toBe("anthropic");
+  });
+
+  it("uses the raw renderer when the student says they are not sure", () => {
+    expect(
+      customTarget({
+        agent: "opencode",
+        provider: CUSTOM_ID,
+        customBaseUrl: "http://localhost:11434",
+        customRenderer: "raw",
+      }).renderer
+    ).toBe("raw");
+  });
+
+  it("warns the student that a raw capture is a JSON dump, not a broken one", () => {
+    const result = customTarget({
+      agent: "opencode",
+      provider: CUSTOM_ID,
+      customBaseUrl: "http://localhost:11434",
+      customRenderer: "raw",
+    });
+    expect(result.notes.join(" ")).toContain("not broken");
+  });
+
+  it("labels a custom target's provider as Custom base URL", () => {
+    expect(
+      customTarget({
+        agent: "opencode",
+        provider: CUSTOM_ID,
+        customBaseUrl: "http://localhost:11434",
+        customRenderer: "openai",
+      }).providerLabel
+    ).toBe("Custom base URL");
+  });
+
+  it("has no catalogue provider id at all", () => {
+    const result = customTarget({
+      agent: "opencode",
+      provider: CUSTOM_ID,
+      customBaseUrl: "http://localhost:11434",
+      customRenderer: "openai",
+    });
+    expect(result).not.toHaveProperty("provider");
+  });
+});
+
+describe("resolveChoice — custom base URL, per-agent command template", () => {
+  it("borrows OpenCode's Anthropic env var and config file for an anthropic-compatible custom target", () => {
+    // The env var and the config file both point the agent at the proxy's own
+    // address (http://localhost:8787), not at the upstream the student typed
+    // — same as every catalogue target. See upstreamBaseUrl for the upstream.
+    const result = customTarget({
+      agent: "opencode",
+      provider: CUSTOM_ID,
+      customBaseUrl: "http://localhost:11434",
+      customRenderer: "anthropic",
+    });
+    expect(result.command).toContain("ANTHROPIC_BASE_URL=http://localhost:8787/v1");
+    expect(result.setup[0].path).toBe("~/.config/opencode/opencode.json");
+    expect(result.upstreamBaseUrl).toBe("http://localhost:11434");
+  });
+
+  it("borrows OpenCode's OpenAI env var for an openai-compatible custom target", () => {
+    const result = customTarget({
+      agent: "opencode",
+      provider: CUSTOM_ID,
+      customBaseUrl: "http://localhost:11434",
+      customRenderer: "openai",
+    });
+    expect(result.command).toContain("OPENAI_BASE_URL=http://localhost:8787/v1");
+  });
+
+  it("defaults OpenCode's raw/not-sure custom target to the OpenAI template", () => {
+    const result = customTarget({
+      agent: "opencode",
+      provider: CUSTOM_ID,
+      customBaseUrl: "http://localhost:11434",
+      customRenderer: "raw",
+    });
+    expect(result.command).toContain("OPENAI_BASE_URL=");
+  });
+
+  it("borrows Pi's OpenAI models file for an openai-compatible custom target", () => {
+    const result = customTarget({
+      agent: "pi",
+      provider: CUSTOM_ID,
+      customBaseUrl: "http://localhost:11434",
+      customRenderer: "openai",
+    });
+    expect(result.setup[0].body).toContain('"openai"');
+    expect(result.setup[0].body).not.toContain('"openai-codex"');
+  });
+
+  it("never borrows Pi's ChatGPT-subscription template for a custom target", () => {
+    const result = customTarget({
+      agent: "pi",
+      provider: CUSTOM_ID,
+      customBaseUrl: "http://localhost:11434",
+      customRenderer: "openai",
+    });
+    expect(result.setup).toHaveLength(1);
+  });
+
+  it("reuses Claude Code's own template regardless of the wire format chosen, since it has only one", () => {
+    const result = customTarget({
+      agent: "claude-code",
+      provider: CUSTOM_ID,
+      customBaseUrl: "http://localhost:11434",
+      customRenderer: "raw",
+    });
+    expect(result.command).toContain("ANTHROPIC_BASE_URL=http://localhost:8787");
+    expect(result.command).toContain("claude");
+    expect(result.upstreamBaseUrl).toBe("http://localhost:11434");
+  });
+
+  it("reuses Copilot's own template regardless of the wire format chosen, since it has only one", () => {
+    const result = customTarget({
+      agent: "copilot",
+      provider: CUSTOM_ID,
+      customBaseUrl: "http://localhost:11434",
+      customRenderer: "anthropic",
+    });
+    expect(result.command).toContain("COPILOT_API_URL=http://localhost:8787");
+  });
+
+  it("never borrows Codex's ChatGPT-subscription template for a custom target", () => {
+    const result = customTarget({
+      agent: "codex",
+      provider: CUSTOM_ID,
+      customBaseUrl: "http://localhost:11434",
+      customRenderer: "openai",
+    });
+    expect(result.command).not.toContain("/backend-api/codex");
+    expect(result.baseUrl).toBe("http://localhost:8787/v1");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// OMP — every setup is custom
+// ---------------------------------------------------------------------------
+
+describe("resolveChoice — OMP", () => {
+  it("resolves OMP straight from a base URL and wire format, with no provider needed", () => {
+    const result = resolveChoice(
+      {
+        agent: "omp",
+        customBaseUrl: "http://localhost:8787",
+        customRenderer: "openai",
+      },
+      PORT
+    );
+    expect(result.kind).toBe("custom-target");
+  });
+
+  it("gives OMP its own bin, with no env vars", () => {
+    const result = customTarget({
+      agent: "omp",
+      customBaseUrl: "http://localhost:11434",
+      customRenderer: "raw",
+    });
+    expect(result.command).toBe("omp");
+  });
+
+  it("gives OMP its YAML models file under ~/.omp/agent/models.yml", () => {
+    const result = customTarget({
+      agent: "omp",
+      customBaseUrl: "http://localhost:11434",
+      customRenderer: "raw",
+    });
+    expect(result.setup).toHaveLength(1);
+    expect(result.setup[0].path).toBe("~/.omp/agent/models.yml");
+    expect(result.setup[0].language).toBe("yaml");
+  });
+
+  it("puts the resolved base URL under a provider key in the YAML file", () => {
+    const result = customTarget({
+      agent: "omp",
+      customBaseUrl: "http://localhost:11434",
+      customRenderer: "raw",
+    });
+    expect(result.setup[0].body).toContain('baseUrl: "http://localhost:8787"');
+    expect(result.setup[0].body).toContain("providers:");
+  });
+
+  it("still resolves OMP even when the saved provider field is stale", () => {
+    // alwaysCustom agents ignore whatever is saved under `provider`; only the
+    // custom base URL and renderer matter.
+    const result = resolveChoice(
+      {
+        agent: "omp",
+        provider: "whatever-was-saved-before",
+        customBaseUrl: "http://localhost:11434",
+        customRenderer: "raw",
+      },
+      PORT
+    );
+    expect(result.kind).toBe("custom-target");
+  });
+
+  it("rejects OMP with no base URL", () => {
+    expect(resolveChoice({ agent: "omp" }, PORT).kind).toBe("error");
   });
 });

--- a/request-logger/agents.ts
+++ b/request-logger/agents.ts
@@ -13,14 +13,28 @@
  * the way a README does.
  *
  * Adding an eighth agent should be one entry here and nothing else.
+ *
+ * Not every student's setup fits a catalogue entry, though — a local model
+ * server or a small provider has no fixed host to hard-code. For those, the
+ * wizard offers "Custom base URL" wherever it offers a provider, and builds a
+ * CustomTarget from what the student types instead of looking one up. See
+ * resolveCustomTarget below.
  */
 
-export type RendererId = "anthropic" | "openai" | "gemini";
+export type RendererId = "anthropic" | "openai" | "gemini" | "raw";
 
-/** What the student picked. This, and only this, is what gets saved to disk. */
+/**
+ * What the student picked. This, and only this, is what gets saved to disk —
+ * except customBaseUrl and customRenderer, which exist only for a custom
+ * target and are the one documented exception. See config.ts.
+ */
 export interface AgentChoice {
   agent: string;
   provider?: string;
+  /** Only set when provider is CUSTOM_ID: the base URL the student typed. */
+  customBaseUrl?: string;
+  /** Only set when provider is CUSTOM_ID: the wire format they chose for it. */
+  customRenderer?: RendererId;
 }
 
 export interface ResolvedTarget {
@@ -41,6 +55,29 @@ export interface ResolvedTarget {
   /** Things worth knowing. Printed under the command. */
   notes: string[];
   /** Things that will otherwise look like the tool is broken. */
+  warnings: string[];
+}
+
+/**
+ * Resolved to a target the catalogue has no entry for: the student typed
+ * their own base URL and picked their own wire format, rather than one being
+ * looked up from a ProviderEntry. It plays the same role as a ResolvedTarget
+ * everywhere downstream — the proxy routes to it and renders it exactly the
+ * same way — so the two are only ever told apart by `kind`.
+ */
+export interface CustomTarget {
+  kind: "custom-target";
+  agent: string;
+  agentLabel: string;
+  /** Always "Custom base URL": there is no catalogue provider label to show. */
+  providerLabel: string;
+  /** The scheme+host[+port] the student typed, with any path stripped. */
+  upstreamBaseUrl: string;
+  renderer: RendererId;
+  baseUrl: string;
+  command: string;
+  setup: SetupFile[];
+  notes: string[];
   warnings: string[];
 }
 
@@ -73,6 +110,7 @@ export interface SetupRequest {
 
 export type Resolution =
   | ResolvedTarget
+  | CustomTarget
   | AgentRefusal
   | ResolveError
   | SetupRequest;
@@ -89,6 +127,28 @@ export const OTHER_ID = "other";
 export const OTHER_LABEL = "Other, or not sure";
 export const ISSUE_URL =
   "https://github.com/ai-hero-dev/ai-coding-crash-course/issues/new";
+
+/**
+ * The option next to "Other" at the provider question: a student whose
+ * provider is not in the catalogue, but who knows its base URL, does not have
+ * to file an issue and wait. This is offered on every supported agent's
+ * provider question, however many catalogue providers it has — see
+ * agentProviders and askChoice in config.ts.
+ */
+export const CUSTOM_ID = "custom";
+export const CUSTOM_LABEL = "Custom base URL";
+
+/**
+ * The wire-format question a custom target answers instead of a renderer
+ * being looked up from a ProviderEntry. "raw" is a real RendererId, not a
+ * placeholder — render.ts checks it first and never guesses at a shape it
+ * was not told.
+ */
+export const WIRE_FORMAT_OPTIONS: Array<{ id: RendererId; label: string }> = [
+  { id: "openai", label: "OpenAI-compatible (chat/completions)" },
+  { id: "anthropic", label: "Anthropic-compatible (messages)" },
+  { id: "raw", label: "Not sure — show me the raw JSON" },
+];
 
 export interface SetupFile {
   path: string;
@@ -121,6 +181,15 @@ interface ProviderEntry {
   setup?: SetupFile[];
   notes?: string[];
   warnings?: string[];
+  /**
+   * Which custom-base-url wire formats this provider's command, env and
+   * setup file are a reasonable stand-in for. Only consulted on an agent
+   * with more than one provider — see findCustomTemplate. A provider tied to
+   * one specific login route (a ChatGPT subscription, a Google account) is
+   * never tagged: reusing its template for an unrelated third-party server
+   * would silently misconfigure it rather than help.
+   */
+  customTemplateFor?: RendererId[];
 }
 
 interface AgentEntry {
@@ -129,6 +198,15 @@ interface AgentEntry {
   /** A supported agent has providers. A refused one has a reason. */
   providers?: ProviderEntry[];
   reason?: string;
+  /**
+   * True when every setup for this agent is a custom target: there is no
+   * fixed catalogue provider to fall back to, so the wizard skips the
+   * provider question and asks the two custom-base-url questions directly.
+   * OMP is the first agent like this — it can point at Ollama, LM Studio,
+   * llama.cpp, LiteLLM, or anything else, so no single upstream host is ever
+   * right for it.
+   */
+  alwaysCustom?: boolean;
 }
 
 /**
@@ -168,6 +246,31 @@ function piModels(providerId: string, baseUrl: string): SetupFile {
     ].join("\n"),
   };
 }
+
+/**
+ * OMP's provider override file, in YAML, under ~/.omp/agent/models.yml.
+ *
+ * OMP does not know, and this tool cannot know, which backend the student is
+ * actually pointing at — Ollama, LM Studio, llama.cpp, LiteLLM, or something
+ * else entirely — so the provider key below is a generic placeholder
+ * ("custom") rather than a real backend name. OMP does not care what the key
+ * is called, only that baseUrl is set correctly under it, so the placeholder
+ * costs the student nothing; they may rename it if they prefer a name that
+ * matches their backend.
+ */
+function ompModels(baseUrl: string): SetupFile {
+  return {
+    path: "~/.omp/agent/models.yml",
+    language: "yaml",
+    body: ["providers:", "  custom:", `    baseUrl: "${baseUrl}"`].join("\n"),
+  };
+}
+
+const OMP_NOTE =
+  "OMP has no backend of its own to hard-code the way the rest of this " +
+  "catalogue does. It can point at Ollama, LM Studio, llama.cpp, LiteLLM, or " +
+  "any other server that speaks one of the wire formats offered here, so " +
+  "every OMP setup goes through the base URL and wire format you chose.";
 
 const OPENCODE_NOTE =
   "The environment variable above works, but only by accident: OpenCode passes " +
@@ -232,6 +335,11 @@ const AGENTS: AgentEntry[] = [
         suffix: "/v1",
         bin: "codex",
         args: ["-c", `'openai_base_url="{baseUrl}"'`],
+        // The only usable template for a custom Codex target: Codex only
+        // ever speaks the OpenAI-compatible wire format, so it is the
+        // catch-all for every choice, including "anthropic" — a mismatch
+        // there is Codex's limitation, not a bug in this tool.
+        customTemplateFor: ["openai", "raw", "anthropic"],
         notes: [CODEX_OVERRIDE_NOTE],
       },
     ],
@@ -284,6 +392,7 @@ const AGENTS: AgentEntry[] = [
         suffix: "/v1",
         env: [["ANTHROPIC_BASE_URL", "{baseUrl}"]],
         bin: "opencode",
+        customTemplateFor: ["anthropic"],
         setup: [
           {
             path: "~/.config/opencode/opencode.json",
@@ -319,6 +428,10 @@ const AGENTS: AgentEntry[] = [
         suffix: "/v1",
         env: [["OPENAI_BASE_URL", "{baseUrl}"]],
         bin: "opencode",
+        // Also the catch-all for "raw"/not sure: a third-party server behind
+        // a custom base URL is far more often OpenAI-compatible than
+        // Anthropic-compatible, so this is the better default guess.
+        customTemplateFor: ["openai", "raw"],
         setup: [
           {
             path: "~/.config/opencode/opencode.json",
@@ -363,6 +476,7 @@ const AGENTS: AgentEntry[] = [
         upstreamHost: "api.anthropic.com",
         renderer: "anthropic",
         bin: "pi",
+        customTemplateFor: ["anthropic"],
         setup: [piModels("anthropic", "{baseUrl}")],
         notes: [
           PI_NOTE,
@@ -379,6 +493,9 @@ const AGENTS: AgentEntry[] = [
         // Pi hands this to the OpenAI SDK, which appends `/responses`.
         suffix: "/v1",
         bin: "pi",
+        // Also the catch-all for "raw"/not sure — see the OpenCode entry
+        // above for why an OpenAI-compatible guess is the better default.
+        customTemplateFor: ["openai", "raw"],
         setup: [piModels("openai", "{baseUrl}")],
         notes: [PI_NOTE],
       },
@@ -414,6 +531,31 @@ const AGENTS: AgentEntry[] = [
     ],
   },
   {
+    id: "omp",
+    label: "OMP (Oh My Pi)",
+    // Every setup for OMP goes through the custom-base-url questions — see
+    // AgentEntry.alwaysCustom. The one provider below never reaches the
+    // wizard; it exists purely to hold the bin and setup-file template that
+    // resolveCustomTarget borrows from, the same way findCustomTemplate
+    // borrows from a real provider for every other agent.
+    alwaysCustom: true,
+    providers: [
+      {
+        id: CUSTOM_ID,
+        label: CUSTOM_LABEL,
+        // Unused: OMP never reaches the normal (non-custom) resolution path
+        // that would read this.
+        upstreamHost: "",
+        // Irrelevant here too — the resolved renderer always comes from the
+        // student's answer, not from this template. See resolveCustomTarget.
+        renderer: "raw",
+        bin: "omp",
+        setup: [ompModels("{baseUrl}")],
+        notes: [OMP_NOTE],
+      },
+    ],
+  },
+  {
     id: "gemini",
     label: "Gemini CLI",
     providers: [
@@ -438,6 +580,13 @@ const AGENTS: AgentEntry[] = [
         renderer: "gemini",
         env: [["GOOGLE_GEMINI_BASE_URL", "{baseUrl}"]],
         bin: "gemini",
+        // The only usable template for a custom Gemini CLI target: the
+        // Google-login route is tied to that login and would misconfigure an
+        // unrelated server. Gemini CLI's own wire format does not actually
+        // match any of the custom choices, so this is a best-effort catch-all
+        // for all three — a mismatch shows up as a renderer warning, not a
+        // silent one.
+        customTemplateFor: ["openai", "anthropic", "raw"],
         warnings: [
           "The two Gemini routes use different variables and they are not " +
             "interchangeable. GOOGLE_GEMINI_BASE_URL is ignored under a Google " +
@@ -467,6 +616,8 @@ export interface AgentSummary {
   supported: boolean;
   /** True when the student must also be asked which model provider they use. */
   needsProvider: boolean;
+  /** True when this agent has no catalogue provider: every setup is custom. */
+  alwaysCustom: boolean;
 }
 
 export interface ProviderSummary {
@@ -488,6 +639,7 @@ export function listAgents(): AgentSummary[] {
     label: agent.label,
     supported: agent.providers != null,
     needsProvider: (agent.providers?.length ?? 0) > 1,
+    alwaysCustom: agent.alwaysCustom === true,
   }));
   return [
     ...summaries.filter((agent) => agent.supported),
@@ -495,11 +647,34 @@ export function listAgents(): AgentSummary[] {
   ];
 }
 
-/** The providers to ask about for one agent. Empty when there is nothing to ask. */
+/**
+ * The providers to ask about for one agent, when there is more than one to
+ * choose between. Empty when there is nothing to ask — a refused agent has
+ * none, and an agent with exactly one provider is assumed rather than asked.
+ *
+ * This stays gated at two on purpose, unchanged by the custom-base-url
+ * mechanism: it describes the catalogue, not the wizard's options. See
+ * agentProviders for the list config.ts actually builds the provider
+ * question's options from, which is not gated this way.
+ */
 export function listProviders(agentId: string): ProviderSummary[] {
   const agent = AGENTS.find((a) => a.id === agentId);
   if (!agent?.providers || agent.providers.length < 2) return [];
   return agent.providers.map((p) => ({ id: p.id, label: p.label }));
+}
+
+/**
+ * Every catalogue provider for one agent, regardless of how many there are.
+ *
+ * config.ts uses this, not listProviders, to build the provider question's
+ * options — because "Custom base URL" is now offered at that question for
+ * every supported agent, even one with a single catalogue provider, there is
+ * always something to pick between even when listProviders would say there
+ * is nothing to ask about.
+ */
+export function agentProviders(agentId: string): ProviderSummary[] {
+  const agent = AGENTS.find((a) => a.id === agentId);
+  return (agent?.providers ?? []).map((p) => ({ id: p.id, label: p.label }));
 }
 
 // ---------------------------------------------------------------------------
@@ -544,6 +719,115 @@ function buildCommand(provider: ProviderEntry, baseUrl: string): string {
 }
 
 /**
+ * Turn what the student typed into an origin (scheme + host [+ port]), or
+ * nothing. Only http and https make sense here — the proxy speaks plain HTTP
+ * to whatever it forwards to, over either transport — so anything else (a
+ * bare host with no scheme, a typo, an unrelated protocol) is rejected
+ * rather than guessed at. A wrong guess would fail as a confusing connection
+ * error; this fails as a message the student can act on.
+ */
+function parseUpstreamUrl(raw: string): URL | null {
+  let url: URL;
+  try {
+    url = new URL(raw.trim());
+  } catch {
+    return null;
+  }
+  if (url.protocol !== "http:" && url.protocol !== "https:") return null;
+  return url;
+}
+
+/**
+ * Which catalogue provider a custom target borrows its command, environment
+ * variable and setup file from. A custom target has no ProviderEntry of its
+ * own, but every agent still needs a real bin to print, and most need a real
+ * env var or config file shape too — this is where those come from instead.
+ *
+ * An agent with exactly one provider has only one thing to borrow, so that
+ * one is used regardless of the wire format chosen: it is a best-effort
+ * template, not a promise, and a mismatch is worth a note, not a dead end.
+ * An agent with more than one provider picks by matching the chosen wire
+ * format against each provider's `customTemplateFor` tags.
+ */
+function findCustomTemplate(
+  agent: AgentEntry,
+  renderer: RendererId
+): ProviderEntry | undefined {
+  const providers = agent.providers ?? [];
+  if (providers.length <= 1) return providers[0];
+  return (
+    providers.find((p) => p.customTemplateFor?.includes(renderer)) ??
+    providers.find((p) => (p.customTemplateFor?.length ?? 0) > 0)
+  );
+}
+
+/**
+ * Build a target from what the student typed, in place of a catalogue
+ * lookup. The only facts on hand are the base URL and the wire format they
+ * chose; everything else is borrowed from the closest matching catalogue
+ * provider — see findCustomTemplate.
+ */
+function resolveCustomTarget(
+  agent: AgentEntry,
+  choice: AgentChoice,
+  port: number
+): Resolution {
+  if (!choice.customBaseUrl) {
+    return {
+      kind: "error",
+      message: `${agent.label} needs a custom base URL. Run with --force to choose again.`,
+    };
+  }
+
+  const upstream = parseUpstreamUrl(choice.customBaseUrl);
+  if (!upstream) {
+    return {
+      kind: "error",
+      message:
+        `"${choice.customBaseUrl}" is not a usable base URL. It must start ` +
+        `with http:// or https://, e.g. http://localhost:11434. Run with ` +
+        `--force to choose again.`,
+    };
+  }
+
+  const renderer: RendererId = choice.customRenderer ?? "raw";
+  const template = findCustomTemplate(agent, renderer);
+  const baseUrl = `http://localhost:${port}${template?.suffix ?? ""}`;
+
+  const notes = [
+    `This command is built from ${agent.label}'s own setup pattern, since a ` +
+      `custom target has no dedicated one of its own. If a note below assumes ` +
+      `a specific login or account, it may not apply to your target.`,
+    ...(template?.notes ?? []),
+  ];
+  if (renderer === "raw") {
+    notes.push(
+      'You picked "not sure" for the wire format, so every capture falls ' +
+        "back to a raw JSON dump instead of a fully rendered one. That is " +
+        "not broken — it is just less readable. Run with --force and pick a " +
+        "format once you know it, and the readable renderer takes over."
+    );
+  }
+
+  return {
+    kind: "custom-target",
+    agent: agent.id,
+    agentLabel: agent.label,
+    providerLabel: CUSTOM_LABEL,
+    upstreamBaseUrl: upstream.origin,
+    renderer,
+    baseUrl,
+    command: template ? buildCommand(template, baseUrl) : agent.id,
+    setup: (template?.setup ?? []).map((file) => ({
+      ...file,
+      body: file.body.replace(/\{baseUrl\}/g, baseUrl),
+    })),
+    notes,
+    warnings: template?.warnings ?? [],
+  };
+}
+
+/**
  * Turn a saved choice into everything the tool needs, or into a clear reason
  * why it cannot.
  *
@@ -583,6 +867,14 @@ export function resolveChoice(
       agentLabel: agent.label,
       reason: agent.reason ?? "This agent cannot be logged.",
     };
+  }
+
+  // A custom target is resolved from what the student typed, not from a
+  // catalogue lookup — either because they chose "Custom base URL" at the
+  // provider question, or because every setup for this agent is custom
+  // (alwaysCustom, e.g. OMP), which never shows that question at all.
+  if (agent.alwaysCustom || choice.provider === CUSTOM_ID) {
+    return resolveCustomTarget(agent, choice, options.port);
   }
 
   let provider: ProviderEntry | undefined;

--- a/request-logger/agents.ts
+++ b/request-logger/agents.ts
@@ -747,7 +747,13 @@ function parseUpstreamUrl(raw: string): URL | null {
  * one is used regardless of the wire format chosen: it is a best-effort
  * template, not a promise, and a mismatch is worth a note, not a dead end.
  * An agent with more than one provider picks by matching the chosen wire
- * format against each provider's `customTemplateFor` tags.
+ * format against each provider's `customTemplateFor` tags — and only that:
+ * an untagged provider is untagged on purpose (see the field's own doc,
+ * above), so a format with no exact match returns `undefined` rather than
+ * borrowing an unrelated provider's command. `resolveCustomTarget` already
+ * degrades honestly when this returns nothing — a bare command, no setup
+ * file, no borrowed notes — which is the correct outcome here, not a bug to
+ * paper over.
  */
 function findCustomTemplate(
   agent: AgentEntry,
@@ -755,10 +761,7 @@ function findCustomTemplate(
 ): ProviderEntry | undefined {
   const providers = agent.providers ?? [];
   if (providers.length <= 1) return providers[0];
-  return (
-    providers.find((p) => p.customTemplateFor?.includes(renderer)) ??
-    providers.find((p) => (p.customTemplateFor?.length ?? 0) > 0)
-  );
+  return providers.find((p) => p.customTemplateFor?.includes(renderer));
 }
 
 /**

--- a/request-logger/config.test.ts
+++ b/request-logger/config.test.ts
@@ -38,6 +38,51 @@ describe("the remembered answer", () => {
   });
 });
 
+describe("the remembered answer — the custom base URL exception", () => {
+  it("reads back a custom base URL and wire format alongside the choice", () => {
+    saveChoice(file, {
+      agent: "opencode",
+      provider: "custom",
+      customBaseUrl: "http://localhost:11434",
+      customRenderer: "openai",
+    });
+    expect(loadChoice(file)).toEqual({
+      agent: "opencode",
+      provider: "custom",
+      customBaseUrl: "http://localhost:11434",
+      customRenderer: "openai",
+    });
+  });
+
+  it("holds nothing but the choice for an ordinary catalogue answer", () => {
+    // The documented exception is only for a custom target. Everything else
+    // still holds nothing beyond {agent, provider} on disk.
+    saveChoice(file, { agent: "codex", provider: "chatgpt" });
+    const raw = JSON.parse(fs.readFileSync(file, "utf8"));
+    expect(Object.keys(raw).sort()).toEqual(["agent", "provider"]);
+  });
+
+  it("saves the custom base URL and renderer on disk for a custom answer", () => {
+    saveChoice(file, {
+      agent: "omp",
+      provider: "custom",
+      customBaseUrl: "http://localhost:11434",
+      customRenderer: "raw",
+    });
+    const raw = JSON.parse(fs.readFileSync(file, "utf8"));
+    expect(raw.customBaseUrl).toBe("http://localhost:11434");
+    expect(raw.customRenderer).toBe("raw");
+  });
+
+  it("ignores a non-string customBaseUrl in a damaged or hand-edited file", () => {
+    fs.writeFileSync(
+      file,
+      JSON.stringify({ agent: "opencode", provider: "custom", customBaseUrl: 42 })
+    );
+    expect(loadChoice(file)?.customBaseUrl).toBeUndefined();
+  });
+});
+
 describe("clearChoice", () => {
   it("removes the file, so the next run asks again", () => {
     saveChoice(file, { agent: "gemini", provider: "api-key" });

--- a/request-logger/config.ts
+++ b/request-logger/config.ts
@@ -7,19 +7,28 @@
  * time the tool starts. A change to the catalogue therefore reaches a student
  * who already has a saved file, without them having to clear anything.
  *
+ * The one documented exception is a custom base URL. It has no catalogue
+ * entry to re-derive from — the student typed it — so for that choice only,
+ * the base URL and the wire format are saved alongside the agent and
+ * provider. Every other choice keeps behaving exactly as described above.
+ *
  * This is glue, not logic. The decisions all live in agents.ts, which is where
  * the tests are.
  */
 
 import fs from "node:fs";
 import { styleText } from "node:util";
-import { cancel, confirm, isCancel, intro, select } from "@clack/prompts";
+import { cancel, confirm, isCancel, intro, select, text } from "@clack/prompts";
 import {
+  agentProviders,
+  CUSTOM_ID,
+  CUSTOM_LABEL,
   listAgents,
-  listProviders,
   OTHER_ID,
   OTHER_LABEL,
+  WIRE_FORMAT_OPTIONS,
   type AgentChoice,
+  type RendererId,
 } from "./agents";
 
 export interface WizardAnswer {
@@ -46,6 +55,14 @@ export function loadChoice(file: string): AgentChoice | null {
     return {
       agent: parsed.agent,
       provider: typeof parsed.provider === "string" ? parsed.provider : undefined,
+      // The one documented exception to "nothing but the choice is saved" —
+      // see the module comment above.
+      customBaseUrl:
+        typeof parsed.customBaseUrl === "string" ? parsed.customBaseUrl : undefined,
+      customRenderer:
+        typeof parsed.customRenderer === "string"
+          ? (parsed.customRenderer as RendererId)
+          : undefined,
     };
   } catch {
     return null;
@@ -92,6 +109,45 @@ function stopIfCancelled<T>(value: T | symbol): T {
   return value as T;
 }
 
+/**
+ * Ask the two custom-base-url questions: the base URL itself, and the wire
+ * format it speaks. Shared by every route into a custom target — the
+ * provider question's "Custom base URL" option, and an alwaysCustom agent
+ * that skips straight here.
+ */
+async function askCustomTarget(): Promise<{ baseUrl: string; renderer: RendererId }> {
+  const baseUrl = stopIfCancelled(
+    await text({
+      message: "What's the base URL of the model server you want to log?",
+      placeholder: "http://localhost:11434",
+      validate: (value) => {
+        if (!value || value.trim().length === 0) return "A base URL is required.";
+        try {
+          const url = new URL(value.trim());
+          if (url.protocol !== "http:" && url.protocol !== "https:") {
+            return "The base URL must start with http:// or https://.";
+          }
+        } catch {
+          return "That does not look like a valid URL.";
+        }
+        return undefined;
+      },
+    })
+  );
+
+  const renderer = stopIfCancelled(
+    await select({
+      message: "Which wire format does it speak?",
+      options: WIRE_FORMAT_OPTIONS.map((format) => ({
+        value: format.id,
+        label: format.label,
+      })),
+    })
+  );
+
+  return { baseUrl: baseUrl.trim(), renderer };
+}
+
 export async function askChoice(options: AskOptions): Promise<WizardAnswer> {
   intro(styleText("bold", " request-logger "));
 
@@ -115,30 +171,61 @@ export async function askChoice(options: AskOptions): Promise<WizardAnswer> {
   if (agentId === OTHER_ID) return { choice: { agent: OTHER_ID }, remember: false };
 
   const agent = agents.find((a) => a.id === agentId);
-  const providers = listProviders(agentId);
 
-  let choice: AgentChoice = { agent: agentId };
-  if (providers.length > 0) {
+  // An agent that cannot be logged is a dead end. Saving it would only make the
+  // student clear the file before they could try a different one, so the
+  // question is not asked at all.
+  if (agent && !agent.supported) return { choice: { agent: agentId }, remember: false };
+
+  let choice: AgentChoice;
+
+  if (agent?.alwaysCustom) {
+    // Every setup for this agent is a custom target — there is no fixed
+    // provider to fall back to, so the provider question is skipped and the
+    // two custom questions are asked directly instead.
+    const custom = await askCustomTarget();
+    choice = {
+      agent: agentId,
+      provider: CUSTOM_ID,
+      customBaseUrl: custom.baseUrl,
+      customRenderer: custom.renderer,
+    };
+  } else {
+    // Every supported agent asks a provider question now, even one with a
+    // single catalogue entry, because "Custom base URL" must be reachable
+    // here too — see agents.ts. A single-provider agent therefore now asks
+    // where it used to assume the only answer.
+    const providers = agentProviders(agentId);
     const providerId = stopIfCancelled(
       await select({
-        message: `${agent?.label ?? agentId} can use more than one model provider. Which one do you use?`,
+        message: `Which model provider do you use with ${agent?.label ?? agentId}?`,
         options: [
           ...providers.map((provider) => ({
             value: provider.id,
             label: provider.label,
           })),
+          { value: CUSTOM_ID, label: CUSTOM_LABEL, hint: "point it anywhere" },
           { value: OTHER_ID, label: OTHER_LABEL },
         ],
       })
     );
-    choice = { agent: agentId, provider: providerId };
-    if (providerId === OTHER_ID) return { choice, remember: false };
-  }
 
-  // An agent that cannot be logged is a dead end. Saving it would only make the
-  // student clear the file before they could try a different one, so the
-  // question is not asked at all.
-  if (agent && !agent.supported) return { choice, remember: false };
+    if (providerId === OTHER_ID) {
+      return { choice: { agent: agentId, provider: OTHER_ID }, remember: false };
+    }
+
+    if (providerId === CUSTOM_ID) {
+      const custom = await askCustomTarget();
+      choice = {
+        agent: agentId,
+        provider: CUSTOM_ID,
+        customBaseUrl: custom.baseUrl,
+        customRenderer: custom.renderer,
+      };
+    } else {
+      choice = { agent: agentId, provider: providerId };
+    }
+  }
 
   if (!options.offerToRemember) return { choice, remember: true };
 

--- a/request-logger/proxy.test.ts
+++ b/request-logger/proxy.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect } from "vitest";
+import { resolveChoice } from "./agents";
+import { upstreamConnection } from "./proxy";
+
+const PORT = { port: 8787 };
+
+/** Resolve, and fail loudly if the answer was not something the proxy can route to. */
+function proxyTarget(...args: Parameters<typeof resolveChoice>) {
+  const result = resolveChoice(...args);
+  if (result.kind !== "target" && result.kind !== "custom-target") {
+    throw new Error(`expected a routable target, got ${result.kind}`);
+  }
+  return result;
+}
+
+describe("upstreamConnection", () => {
+  it("keeps a catalogue target on https and port 443, unchanged", () => {
+    const target = proxyTarget({ agent: "claude-code" }, PORT);
+    expect(upstreamConnection(target)).toEqual({
+      hostname: "api.anthropic.com",
+      port: 443,
+      useHttps: true,
+    });
+  });
+
+  it("keeps every catalogue target on https and 443, whichever agent it is", () => {
+    const target = proxyTarget({ agent: "gemini", provider: "api-key" }, PORT);
+    expect(upstreamConnection(target)).toEqual({
+      hostname: "generativelanguage.googleapis.com",
+      port: 443,
+      useHttps: true,
+    });
+  });
+
+  it("uses https on a custom target whose base URL says https, with no port given", () => {
+    const target = proxyTarget(
+      {
+        agent: "opencode",
+        provider: "custom",
+        customBaseUrl: "https://api.deepseek.com",
+        customRenderer: "openai",
+      },
+      PORT
+    );
+    expect(upstreamConnection(target)).toEqual({
+      hostname: "api.deepseek.com",
+      port: 443,
+      useHttps: true,
+    });
+  });
+
+  it("uses http on a custom target whose base URL says http, with an explicit port", () => {
+    const target = proxyTarget(
+      {
+        agent: "omp",
+        customBaseUrl: "http://localhost:11434",
+        customRenderer: "raw",
+      },
+      PORT
+    );
+    expect(upstreamConnection(target)).toEqual({
+      hostname: "localhost",
+      port: 11434,
+      useHttps: false,
+    });
+  });
+
+  it("defaults a plain http:// custom target with no explicit port to 80", () => {
+    const target = proxyTarget(
+      {
+        agent: "omp",
+        customBaseUrl: "http://model-server.internal",
+        customRenderer: "raw",
+      },
+      PORT
+    );
+    expect(upstreamConnection(target)).toEqual({
+      hostname: "model-server.internal",
+      port: 80,
+      useHttps: false,
+    });
+  });
+
+  it("defaults a plain https:// custom target with no explicit port to 443", () => {
+    const target = proxyTarget(
+      {
+        agent: "omp",
+        customBaseUrl: "https://model-server.internal",
+        customRenderer: "raw",
+      },
+      PORT
+    );
+    expect(upstreamConnection(target)).toEqual({
+      hostname: "model-server.internal",
+      port: 443,
+      useHttps: true,
+    });
+  });
+
+  it("respects an explicit port on an https:// custom target too", () => {
+    const target = proxyTarget(
+      {
+        agent: "omp",
+        customBaseUrl: "https://model-server.internal:8443",
+        customRenderer: "raw",
+      },
+      PORT
+    );
+    expect(upstreamConnection(target)).toEqual({
+      hostname: "model-server.internal",
+      port: 8443,
+      useHttps: true,
+    });
+  });
+});

--- a/request-logger/proxy.ts
+++ b/request-logger/proxy.ts
@@ -27,9 +27,18 @@ import {
   resolveChoice,
   shouldLogRequest,
   type AgentChoice,
+  type CustomTarget,
   type ResolvedTarget,
 } from "./agents";
 import { askChoice, clearChoice, loadChoice, saveChoice } from "./config";
+
+/**
+ * A resolved target the proxy can actually route to and render: a catalogue
+ * ResolvedTarget or a student-typed CustomTarget. The two are used
+ * interchangeably everywhere below except upstreamConnection, which is the
+ * one place their upstream host is found differently.
+ */
+type ProxyTarget = ResolvedTarget | CustomTarget;
 
 const PORT = Number(process.env.PORT ?? 8787);
 
@@ -42,10 +51,37 @@ const STATE_FILE = path.join(HERE, ".agent-choice.json");
 // ---------------------------------------------------------------------------
 
 /** Build a filesystem-safe base name: 2026-07-07T14-32-05-123_claude-code */
-function baseName(target: ResolvedTarget): string {
+function baseName(target: ProxyTarget): string {
   const iso = new Date().toISOString(); // 2026-07-07T14:32:05.123Z
   const stamp = iso.replace(/:/g, "-").replace(".", "-").replace("Z", "");
   return `${stamp}_${target.agent}`;
+}
+
+/**
+ * Where a target's traffic actually goes: a scheme, a host and a port.
+ *
+ * A catalogue ResolvedTarget is always HTTPS on 443 — every provider in the
+ * catalogue is a public HTTPS API, so this has never needed to vary, and
+ * still does not: it is read straight off upstreamHost, unchanged. A
+ * CustomTarget can be anything the student typed, including plain HTTP on an
+ * arbitrary port (a local Ollama server, say), so its scheme and port are
+ * parsed from the base URL instead of assumed.
+ */
+export function upstreamConnection(target: ProxyTarget): {
+  hostname: string;
+  port: number;
+  useHttps: boolean;
+} {
+  if (target.kind === "target") {
+    return { hostname: target.upstreamHost, port: 443, useHttps: true };
+  }
+  const url = new URL(target.upstreamBaseUrl);
+  const useHttps = url.protocol === "https:";
+  return {
+    hostname: url.hostname,
+    port: url.port ? Number(url.port) : useHttps ? 443 : 80,
+    useHttps,
+  };
 }
 
 /**
@@ -76,7 +112,7 @@ function forwardHeaders(
 function handle(
   req: http.IncomingMessage,
   res: http.ServerResponse,
-  target: ResolvedTarget
+  target: ProxyTarget
 ): void {
   const reqPath = req.url ?? "/";
 
@@ -87,43 +123,46 @@ function handle(
     const timestamp = new Date().toISOString();
     const base = baseName(target);
     const encoding = req.headers["content-encoding"];
+    const { hostname, port, useHttps } = upstreamConnection(target);
 
-    const upstreamReq = https.request(
-      {
-        hostname: target.upstreamHost,
-        port: 443,
-        path: reqPath,
-        method: req.method,
-        headers: {
-          ...forwardHeaders(req.headers, body),
-          host: target.upstreamHost,
-        },
+    const onUpstreamResponse = (upstreamRes: http.IncomingMessage) => {
+      res.writeHead(upstreamRes.statusCode ?? 502, upstreamRes.headers);
+      const responseChunks: Buffer[] = [];
+      upstreamRes.on("data", (chunk: Buffer) => {
+        responseChunks.push(chunk);
+        res.write(chunk); // stream straight back to the agent, unbuffered
+      });
+      upstreamRes.on("end", () => {
+        res.end();
+        const responseRaw = Buffer.concat(responseChunks).toString("utf8");
+        writeCapture({
+          base,
+          target,
+          timestamp,
+          method: req.method ?? "POST",
+          path: reqPath,
+          statusCode: upstreamRes.statusCode ?? 0,
+          headers: req.headers,
+          requestBody: body,
+          requestEncoding: Array.isArray(encoding) ? encoding[0] : encoding,
+          responseRaw,
+        });
+      });
+    };
+
+    const requestOptions: http.RequestOptions = {
+      hostname,
+      port,
+      path: reqPath,
+      method: req.method,
+      headers: {
+        ...forwardHeaders(req.headers, body),
+        host: hostname,
       },
-      (upstreamRes) => {
-        res.writeHead(upstreamRes.statusCode ?? 502, upstreamRes.headers);
-        const responseChunks: Buffer[] = [];
-        upstreamRes.on("data", (chunk: Buffer) => {
-          responseChunks.push(chunk);
-          res.write(chunk); // stream straight back to the agent, unbuffered
-        });
-        upstreamRes.on("end", () => {
-          res.end();
-          const responseRaw = Buffer.concat(responseChunks).toString("utf8");
-          writeCapture({
-            base,
-            target,
-            timestamp,
-            method: req.method ?? "POST",
-            path: reqPath,
-            statusCode: upstreamRes.statusCode ?? 0,
-            headers: req.headers,
-            requestBody: body,
-            requestEncoding: Array.isArray(encoding) ? encoding[0] : encoding,
-            responseRaw,
-          });
-        });
-      }
-    );
+    };
+    const upstreamReq = useHttps
+      ? https.request(requestOptions, onUpstreamResponse)
+      : http.request(requestOptions, onUpstreamResponse);
 
     upstreamReq.on("error", (err) => {
       console.error(`[request-logger] upstream error: ${err.message}`);
@@ -142,7 +181,7 @@ function handle(
 
 interface Capture {
   base: string;
-  target: ResolvedTarget;
+  target: ProxyTarget;
   timestamp: string;
   method: string;
   path: string;
@@ -209,13 +248,15 @@ function field(label: string, value: string): void {
   console.log(`  ${dim(label.padEnd(10))} ${value}`);
 }
 
-function printBanner(target: ResolvedTarget): void {
+function printBanner(target: ProxyTarget): void {
   const rule = dim("-".repeat(72));
+  const forwards =
+    target.kind === "target" ? `https://${target.upstreamHost}` : target.upstreamBaseUrl;
   console.log("");
   console.log(rule);
   field("Agent", bold(`${target.agentLabel} (${target.providerLabel})`));
   field("Listening", `http://localhost:${PORT}`);
-  field("Forwards", `https://${target.upstreamHost}`);
+  field("Forwards", forwards);
   field("Logs", dim(LOG_DIR));
   console.log(rule);
 
@@ -374,7 +415,14 @@ function wrap(text: string, width: number): string[] {
   return lines;
 }
 
-main().catch((err) => {
-  console.error(`[request-logger] ${(err as Error).message}`);
-  process.exit(1);
-});
+// Only start the wizard and the server when this file is run directly (`npm
+// run request-logger`, or `tsx request-logger/proxy.ts`), not when it is
+// imported — the tests import pure functions like upstreamConnection from
+// this module, and must not trigger the interactive wizard by doing so.
+const isMain = path.resolve(process.argv[1] ?? "") === fileURLToPath(import.meta.url);
+if (isMain) {
+  main().catch((err) => {
+    console.error(`[request-logger] ${(err as Error).message}`);
+    process.exit(1);
+  });
+}

--- a/request-logger/render.test.ts
+++ b/request-logger/render.test.ts
@@ -163,6 +163,94 @@ describe("renderMarkdown for OpenAI", () => {
 });
 
 // ---------------------------------------------------------------------------
+// "raw" — the explicit fallback for a custom target with no known wire format
+// ---------------------------------------------------------------------------
+
+describe('renderMarkdown for the "raw" renderer', () => {
+  // Deliberately shaped like an OpenAI /responses request, so a test failure
+  // here would show the bug this renderer exists to prevent: "raw" quietly
+  // falling through to the OpenAI parser instead of the generic JSON dump.
+  const request = {
+    model: "some-local-model",
+    instructions: "You are a careful assistant.",
+    input: [{ type: "message", role: "user", content: "hello" }],
+  };
+
+  const out = renderMarkdown({
+    ...BASE,
+    agent: "OMP",
+    renderer: "raw",
+    path: "/v1/chat/completions",
+    requestBody: body(request),
+    responseRaw: JSON.stringify({ choices: [{ message: { content: "hi" } }] }),
+  });
+
+  it("dumps the request as plain JSON, not through the OpenAI parser", () => {
+    expect(out).not.toContain("<system-prompt>");
+    expect(out).not.toContain("<messages>");
+  });
+
+  it("still shows the request content somewhere in the JSON dump", () => {
+    expect(out).toContain("You are a careful assistant.");
+  });
+
+  it("dumps a non-streaming response as plain JSON, not through the OpenAI parser", () => {
+    expect(out).not.toContain("<assistant-text>");
+    expect(out).toContain('"content": "hi"');
+  });
+
+  it("still finds the model name, because that reading does not depend on the renderer", () => {
+    expect(out).toContain("**model**: some-local-model");
+  });
+
+  it("dumps each SSE event as its own JSON block instead of reconstructing assistant text", () => {
+    const streamed = renderMarkdown({
+      ...BASE,
+      agent: "OMP",
+      renderer: "raw",
+      path: "/v1/chat/completions",
+      requestBody: body(request),
+      responseRaw:
+        'data: {"choices":[{"delta":{"content":"hi"}}]}\n' +
+        'data: {"choices":[{"delta":{"content":" there"}}]}\n',
+    });
+    expect(streamed).not.toContain("<assistant-text>");
+    expect(streamed).toContain('"content": "hi"');
+    expect(streamed).toContain('"content": " there"');
+  });
+
+  it("falls back to the untouched raw text for a stream it cannot parse at all", () => {
+    // Stands in for Ollama's NDJSON: bare JSON objects, one per line, with no
+    // `data:` prefix — genuinely different from SSE, and out of scope here.
+    // The one promise this renderer makes for that shape is "not broken".
+    const ndjson =
+      '{"model":"llama3","message":{"content":"hi"}}\n' +
+      '{"model":"llama3","message":{"content":" there"},"done":true}\n';
+    const out = renderMarkdown({
+      ...BASE,
+      agent: "OMP",
+      renderer: "raw",
+      path: "/api/chat",
+      requestBody: body(request),
+      responseRaw: ndjson,
+    });
+    expect(out).toContain('"content":"hi"');
+  });
+
+  it("does not treat an unparseable body as raw JSON, and falls back to raw text", () => {
+    const out = renderMarkdown({
+      ...BASE,
+      agent: "OMP",
+      renderer: "raw",
+      path: "/v1/chat/completions",
+      requestBody: Buffer.from("not json at all"),
+      responseRaw: "",
+    });
+    expect(out).toContain("not json at all");
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Gemini
 // ---------------------------------------------------------------------------
 

--- a/request-logger/render.ts
+++ b/request-logger/render.ts
@@ -152,6 +152,14 @@ function renderRequest(
   reqJson: any,
   requestText: string
 ): string {
+  // Checked first and explicitly: without this, "raw" is not "anthropic" and
+  // not "gemini", so it would silently fall into the OpenAI parser below —
+  // the same implicit default every other unrecognised renderer id already
+  // falls into. "raw" must never guess at a shape it was not told; it always
+  // goes straight to the generic fallback instead.
+  if (input.renderer === "raw") {
+    return reqJson == null ? fence(requestText) : fenceJson(reqJson);
+  }
   if (reqJson == null) {
     return fence(requestText);
   }
@@ -647,6 +655,26 @@ function renderResponse(input: RenderInput, reqJson: any): string {
   if (raw.trim().length === 0) return "_(empty response)_";
 
   const looksSSE = /(^|\n)\s*(event:|data:)/.test(raw);
+
+  // Checked first and explicitly, for the same reason as renderRequest
+  // above: "raw" must never fall through into the OpenAI stream parser.
+  // Ollama's own response shape — newline-delimited bare JSON, no `data:`
+  // prefix — is not reconstructed here; that is a separate fast-follow. This
+  // path still shows something rather than nothing: an SSE-ish stream is
+  // dumped one parsed event per JSON block, and anything else (including
+  // Ollama's NDJSON) falls back to the untouched raw text.
+  if (input.renderer === "raw") {
+    try {
+      if (!looksSSE) return fenceJson(JSON.parse(raw));
+      const events = sseData(raw);
+      return events.length > 0
+        ? events.map((event) => fenceJson(event)).join("\n\n")
+        : fence(raw);
+    } catch {
+      return fence(raw);
+    }
+  }
+
   try {
     if (!looksSSE) {
       // Non-streaming JSON body.


### PR DESCRIPTION
## Summary

Two students hit the same wall from different directions: OhMyPi (a Pi fork)
pointed at a local model with no fixed host, and OpenCode pointed at DeepSeek.
Both landed on the wizard's "Other, or not sure" dead end, which only offers a
link to file an issue and wait.

This adds a general **"Custom base URL"** option next to "Other, or not sure"
at every supported agent's provider question. Picking it asks two questions
instead of dead-ending:

- the base URL of the model server to log (`http://localhost:11434` for
  Ollama, `https://api.deepseek.com` for DeepSeek, ...), and
- which wire format it speaks — OpenAI-compatible, Anthropic-compatible, or
  "not sure" (falls back to a raw JSON dump — see below).

**OMP** ("Oh My Pi") also gets a full named catalogue entry, the same tier of
treatment as Pi and Codex — bin, setup file, notes — not just the bare custom
mechanism. It has no fixed backend of its own (Ollama, LM Studio, llama.cpp,
LiteLLM are all fair game), so its entry routes straight into the two custom
questions rather than showing a provider list.

This is exactly what was promised in the comments on #15 and #12.

### What's in scope

- `agents.ts`: a `CustomTarget` `Resolution` variant, a `"raw"` `RendererId`,
  the `CUSTOM_ID` / `CUSTOM_LABEL` / `WIRE_FORMAT_OPTIONS` catalogue data, and
  the OMP `AgentEntry` (`alwaysCustom: true`).
- `proxy.ts`: stops hardcoding `https`/port `443` — parses scheme, host and
  port from a custom target's base URL, so plain HTTP on an arbitrary port
  (a local Ollama server, say) works. Every catalogue entry keeps behaving
  exactly as before (still `https://host:443`) — see `proxy.test.ts`. Also
  guards `main()` behind an entry-point check so the new pure functions
  (`upstreamConnection`) can be imported by tests without starting the
  interactive wizard.
- `render.ts`: `"raw"` is checked first and explicitly in both
  `renderRequest` and `renderResponse`, so it can never silently fall through
  to the OpenAI parser the way an unrecognised renderer id implicitly did
  before.
- `config.ts`: documents and implements the one exception to "the save file
  holds nothing but the choice" — a custom target's base URL and wire format
  are saved too, since there is no catalogue entry to re-derive them from on
  the next run.
- `README.md`: documents the new wizard option, the save-file exception, OMP
  in the agent table (marked tested end-to-end, per how it's actually used),
  and updates "Extending it" for the `alwaysCustom` shape.

### Explicitly out of scope (filed as a fast-follow, per the issue comments)

Ollama's own response format (newline-delimited bare JSON, no `data:` SSE
prefix) is genuinely different work from SSE reconstruction. For now an Ollama
target works via the `"raw"` fallback — an ugly JSON dump, but not broken.

### Design judgement calls worth a second look

- **Every supported agent now asks a provider question**, even ones with a
  single catalogue provider (Claude Code, Copilot) — previously that question
  was skipped entirely when there was nothing to choose between. This was
  necessary so "Custom base URL" is reachable there too, per the spec, but it
  is a visible wizard change for those two agents.
- **Custom-target commands are built by borrowing a real `ProviderEntry`**
  (env var, bin, setup-file shape) from the same agent, picked by matching the
  chosen wire format against a new `customTemplateFor` tag on each provider.
  An agent with only one provider (Claude Code, Copilot) always reuses it,
  regardless of wire format, with a note added that it may not apply. A
  provider tied to one specific login (ChatGPT subscription, Google account)
  is never used as a template, since reusing it would silently misconfigure
  an unrelated third-party server.
- **OMP's YAML provider key is a generic placeholder (`custom`)**, not a real
  backend name, since the tool has no way to know whether the student is
  pointing at Ollama, LM Studio, llama.cpp, or something else. Documented in
  a code comment on `ompModels` in `agents.ts`.

## Test plan

- [x] `npm run test` — 480 tests pass, including new coverage for the custom
      resolution path (valid/malformed URLs, each wire format), the `"raw"`
      renderer in both request and response (proving it does not fall through
      to the OpenAI parser), `proxy.ts`'s scheme/port derivation for both
      `http://`/`https://` custom targets and unchanged catalogue behaviour,
      and the OMP entry's command/setup output.
- [x] `npm run typecheck` — clean.
- [x] Manual smoke test of the live interactive wizard (agent → provider →
      "Custom base URL" → base URL prompt → wire format select), and of OMP's
      `alwaysCustom` path skipping the provider question.
- [x] No `lint:boundaries` script exists in this repo (checked `package.json`).

Closes #15
Closes #12