### PR TITLE
Enhance OpenCode custom targets with model discovery

### DIFF
--- a/request-logger/README.md
+++ b/request-logger/README.md
@@ -5,7 +5,7 @@ model provider's API, and writes a **readable Markdown document for every
 request**: the real system prompt, the tool definitions, and the messages your
 agent sends to the model.
 
-It was built for the AI Coding Crash Course so that you can *see* what actually
+It was built for the AI Coding Crash Course so that you can _see_ what actually
 goes over the wire.
 
 ## Run it
@@ -42,6 +42,14 @@ If you are not sure, pick "not sure". The tool still logs everything; it just
 shows you the raw JSON instead of a fully readable render, because it cannot
 safely guess a shape you did not tell it. See "What you get" below.
 
+For **OpenCode** with an **OpenAI-compatible** custom target, the wizard also
+tries the unauthenticated `/v1/models` endpoint and offers any model IDs it
+finds. You can always enter an ID manually, and the wizard falls back to manual
+entry if discovery fails. Endpoints that require credentials for model listing
+are not supported. The printed command uses a temporary
+`OPENCODE_CONFIG_CONTENT` provider for that one run, merged with your existing
+OpenCode configuration without editing its file.
+
 To change a remembered answer:
 
 ```bash
@@ -65,26 +73,28 @@ you having to clear anything.
 
 The one exception is a **Custom base URL** answer. There is no catalogue entry
 for it to be worked out from — you typed it — so the base URL and the wire
-format you chose are saved in the file too, alongside your choice. Everything
-else about a custom answer still behaves the same way: change it any time with
-`--force`, and it is never kept for an agent that cannot be logged.
+format you chose are saved in the file too, alongside your choice. OpenCode's
+OpenAI-compatible custom route also saves the selected model ID, so a remembered
+choice starts without repeating discovery. Everything else about a custom
+answer still behaves the same way: change it any time with `--force`, and it is
+never kept for an agent that cannot be logged.
 
 ## The agents
 
 The tool prints the correct command for you, so you do not have to copy anything
 from this table. It is here so you can see what is supported before you start.
 
-| Agent            | Works | What you need                                   |
-| ---------------- | ----- | ----------------------------------------------- |
-| Claude Code      | Yes   | One command. Works with a subscription login.    |
-| Codex            | Yes   | One flag. A subscription or an API key works.    |
-| GitHub Copilot   | Yes   | Your normal subscription login.                  |
-| OpenCode         | Yes   | One command, or a config file.                   |
-| Pi               | Yes   | A config file. Pi has no base URL variable.      |
-| OMP              | Yes   | A YAML config file. Point it at any backend.     |
-| Gemini CLI       | Yes   | One command. The free Google login works.        |
-| Cursor CLI       | No    | Nothing can make it work. See below.             |
-| Amp              | No    | Nothing can make it work. See below.             |
+| Agent          | Works | What you need                                 |
+| -------------- | ----- | --------------------------------------------- |
+| Claude Code    | Yes   | One command. Works with a subscription login. |
+| Codex          | Yes   | One flag. A subscription or an API key works. |
+| GitHub Copilot | Yes   | Your normal subscription login.               |
+| OpenCode       | Yes   | One command, or a config file.                |
+| Pi             | Yes   | A config file. Pi has no base URL variable.   |
+| OMP            | Yes   | A YAML config file. Point it at any backend.  |
+| Gemini CLI     | Yes   | One command. The free Google login works.     |
+| Cursor CLI     | No    | Nothing can make it work. See below.          |
+| Amp            | No    | Nothing can make it work. See below.          |
 
 Any other provider — a local model server, or a smaller hosted one — works
 through **Custom base URL**, above, on any agent in this table except Cursor
@@ -124,10 +134,10 @@ the effect off.
 
 Measured through this tool with the same prompt:
 
-| Run                             | Capture size |
-| ------------------------------- | ------------ |
-| Base URL only                    | 63,596 bytes |
-| With `ENABLE_TOOL_SEARCH=true`   | 39,013 bytes |
+| Run                            | Capture size |
+| ------------------------------ | ------------ |
+| Base URL only                  | 63,596 bytes |
+| With `ENABLE_TOOL_SEARCH=true` | 39,013 bytes |
 
 That is 39% smaller, and the tool-search tool appears only in the second
 capture.
@@ -137,11 +147,11 @@ capture.
 Every request writes three files to `request-logger/logs/`, which is gitignored.
 They share a base name such as `2026-07-07T14-32-05-123_claude-code`:
 
-| File            | Contents                                             |
-| --------------- | ---------------------------------------------------- |
-| `.md`           | The readable render. Start here.                     |
-| `.request.txt`  | The request body exactly as it was sent.             |
-| `.response.txt` | The raw response stream.                             |
+| File            | Contents                                 |
+| --------------- | ---------------------------------------- |
+| `.md`           | The readable render. Start here.         |
+| `.request.txt`  | The request body exactly as it was sent. |
+| `.response.txt` | The raw response stream.                 |
 
 The `.md` file uses **XML tags** (`<request>`, `<system-prompt>`, `<tools>`,
 `<messages>`, `<response>`) to mark its sections, because the captured content is

--- a/request-logger/agents.test.ts
+++ b/request-logger/agents.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "vitest";
+import { execFileSync } from "node:child_process";
 import {
   agentProviders,
   CUSTOM_ID,
@@ -88,7 +89,9 @@ describe("listAgents", () => {
 
   it("puts every agent that can be logged above every agent that cannot", () => {
     const supported = listAgents().map((agent) => agent.supported);
-    expect(supported.indexOf(false)).toBeGreaterThan(supported.lastIndexOf(true));
+    expect(supported.indexOf(false)).toBeGreaterThan(
+      supported.lastIndexOf(true)
+    );
   });
 
   it("marks Cursor as unsupported", () => {
@@ -164,7 +167,9 @@ describe("listProviders", () => {
 describe("agentProviders", () => {
   it("returns the one provider a single-provider agent has, unlike listProviders", () => {
     expect(listProviders("claude-code")).toEqual([]);
-    expect(agentProviders("claude-code").map((p) => p.id)).toEqual(["anthropic"]);
+    expect(agentProviders("claude-code").map((p) => p.id)).toEqual([
+      "anthropic",
+    ]);
   });
 
   it("returns the one provider Copilot has too", () => {
@@ -207,7 +212,9 @@ describe("resolveChoice — upstream hosts", () => {
   });
 
   it("sends OpenCode on Anthropic to Anthropic", () => {
-    expect(target("opencode", "anthropic").upstreamHost).toBe("api.anthropic.com");
+    expect(target("opencode", "anthropic").upstreamHost).toBe(
+      "api.anthropic.com"
+    );
   });
 
   it("sends OpenCode on OpenAI to OpenAI", () => {
@@ -307,7 +314,9 @@ describe("resolveChoice — base URLs", () => {
   it("gives Pi on a ChatGPT subscription the /backend-api suffix", () => {
     // Pi appends /codex/responses itself, and the real endpoint sits under
     // /backend-api. Without the suffix the forwarded path loses that segment.
-    expect(target("pi", "codex").baseUrl).toBe("http://localhost:8787/backend-api");
+    expect(target("pi", "codex").baseUrl).toBe(
+      "http://localhost:8787/backend-api"
+    );
   });
 
   it("uses the port it is given", () => {
@@ -428,7 +437,9 @@ describe("resolveChoice — setup files", () => {
   });
 
   it("gives Pi its models file, because Pi has no variable to set", () => {
-    expect(target("pi", "anthropic").setup[0].path).toBe("~/.pi/agent/models.json");
+    expect(target("pi", "anthropic").setup[0].path).toBe(
+      "~/.pi/agent/models.json"
+    );
   });
 
   it("uses Pi's exact spelling of the base URL key", () => {
@@ -465,7 +476,9 @@ describe("resolveChoice — setup files", () => {
 
 describe("resolveChoice — notes and warnings", () => {
   it("explains the tool search flag to a Claude Code student", () => {
-    expect(target("claude-code").notes.join(" ")).toContain("ENABLE_TOOL_SEARCH");
+    expect(target("claude-code").notes.join(" ")).toContain(
+      "ENABLE_TOOL_SEARCH"
+    );
   });
 
   it("tells a Codex student the flag does not touch their config file", () => {
@@ -531,9 +544,9 @@ describe("resolveChoice — refusals", () => {
 
 describe("shouldLogRequest", () => {
   it("logs a real Anthropic turn", () => {
-    expect(shouldLogRequest("POST", "/v1/messages?beta=true", "anthropic")).toBe(
-      true
-    );
+    expect(
+      shouldLogRequest("POST", "/v1/messages?beta=true", "anthropic")
+    ).toBe(true);
   });
 
   it("drops Anthropic token counting", () => {
@@ -580,20 +593,24 @@ describe("shouldLogRequest", () => {
 
   it("drops Gemini token counting, which has its own name", () => {
     expect(
-      shouldLogRequest("POST", "/v1beta/models/gemini-2.5-pro:countTokens", "gemini")
+      shouldLogRequest(
+        "POST",
+        "/v1beta/models/gemini-2.5-pro:countTokens",
+        "gemini"
+      )
     ).toBe(false);
   });
 
   it("drops the Google login housekeeping calls, which carry no prompt", () => {
-    expect(shouldLogRequest("POST", "/v1internal:loadCodeAssist", "gemini")).toBe(
-      false
-    );
-    expect(shouldLogRequest("POST", "/v1internal:retrieveUserQuota", "gemini")).toBe(
-      false
-    );
-    expect(shouldLogRequest("POST", "/v1internal:listExperiments", "gemini")).toBe(
-      false
-    );
+    expect(
+      shouldLogRequest("POST", "/v1internal:loadCodeAssist", "gemini")
+    ).toBe(false);
+    expect(
+      shouldLogRequest("POST", "/v1internal:retrieveUserQuota", "gemini")
+    ).toBe(false);
+    expect(
+      shouldLogRequest("POST", "/v1internal:listExperiments", "gemini")
+    ).toBe(false);
     expect(
       shouldLogRequest("POST", "/v1internal:recordCodeAssistMetrics", "gemini")
     ).toBe(false);
@@ -620,9 +637,9 @@ describe("resolveChoice — bad input", () => {
   });
 
   it("rejects an unknown provider", () => {
-    expect(resolveChoice({ agent: "opencode", provider: "cohere" }, PORT).kind).toBe(
-      "error"
-    );
+    expect(
+      resolveChoice({ agent: "opencode", provider: "cohere" }, PORT).kind
+    ).toBe("error");
   });
 
   it("accepts a single-provider agent with no provider given", () => {
@@ -652,6 +669,7 @@ describe("resolveChoice — custom base URL", () => {
       provider: CUSTOM_ID,
       customBaseUrl: "http://localhost:11434",
       customRenderer: "openai",
+      customModel: "test-model",
     });
     expect(result.upstreamBaseUrl).toBe("http://localhost:11434");
   });
@@ -662,6 +680,7 @@ describe("resolveChoice — custom base URL", () => {
       provider: CUSTOM_ID,
       customBaseUrl: "https://api.deepseek.com",
       customRenderer: "openai",
+      customModel: "test-model",
     });
     expect(result.upstreamBaseUrl).toBe("https://api.deepseek.com");
   });
@@ -672,13 +691,18 @@ describe("resolveChoice — custom base URL", () => {
       provider: CUSTOM_ID,
       customBaseUrl: "https://api.deepseek.com/v1/some/path",
       customRenderer: "openai",
+      customModel: "test-model",
     });
     expect(result.upstreamBaseUrl).toBe("https://api.deepseek.com");
   });
 
   it("rejects a base URL with no scheme", () => {
     const result = resolveChoice(
-      { agent: "opencode", provider: CUSTOM_ID, customBaseUrl: "localhost:11434" },
+      {
+        agent: "opencode",
+        provider: CUSTOM_ID,
+        customBaseUrl: "localhost:11434",
+      },
       PORT
     );
     expect(result.kind).toBe("error");
@@ -694,7 +718,11 @@ describe("resolveChoice — custom base URL", () => {
 
   it("rejects a base URL with an unrelated scheme", () => {
     const result = resolveChoice(
-      { agent: "opencode", provider: CUSTOM_ID, customBaseUrl: "ftp://example.com" },
+      {
+        agent: "opencode",
+        provider: CUSTOM_ID,
+        customBaseUrl: "ftp://example.com",
+      },
       PORT
     );
     expect(result.kind).toBe("error");
@@ -717,7 +745,10 @@ describe("resolveChoice — custom base URL", () => {
   });
 
   it("rejects a custom choice with no base URL at all", () => {
-    const result = resolveChoice({ agent: "opencode", provider: CUSTOM_ID }, PORT);
+    const result = resolveChoice(
+      { agent: "opencode", provider: CUSTOM_ID },
+      PORT
+    );
     expect(result.kind).toBe("error");
   });
 
@@ -737,6 +768,7 @@ describe("resolveChoice — custom base URL", () => {
         provider: CUSTOM_ID,
         customBaseUrl: "http://localhost:11434",
         customRenderer: "openai",
+        customModel: "test-model",
       }).renderer
     ).toBe("openai");
   });
@@ -780,6 +812,7 @@ describe("resolveChoice — custom base URL", () => {
         provider: CUSTOM_ID,
         customBaseUrl: "http://localhost:11434",
         customRenderer: "openai",
+        customModel: "test-model",
       }).providerLabel
     ).toBe("Custom base URL");
   });
@@ -790,12 +823,83 @@ describe("resolveChoice — custom base URL", () => {
       provider: CUSTOM_ID,
       customBaseUrl: "http://localhost:11434",
       customRenderer: "openai",
+      customModel: "test-model",
     });
     expect(result).not.toHaveProperty("provider");
   });
 });
 
 describe("resolveChoice — custom base URL, per-agent command template", () => {
+  it("builds a one-run OpenCode provider config for the OpenAI-compatible route", () => {
+    const result = customTarget({
+      agent: "opencode",
+      provider: CUSTOM_ID,
+      customBaseUrl: "http://localhost:11434",
+      customRenderer: "openai",
+      customModel: "qwen3:8b",
+    });
+    const assignment = result.command.slice(0, -" opencode".length);
+    const serialized = execFileSync(
+      "/bin/sh",
+      [
+        "-c",
+        `${assignment} node -e 'process.stdout.write(process.env.OPENCODE_CONFIG_CONTENT)'`,
+      ],
+      { encoding: "utf8" }
+    );
+    const config = JSON.parse(serialized);
+
+    expect(config.provider["request-logger"]).toEqual({
+      npm: "@ai-sdk/openai-compatible",
+      name: "Request Logger",
+      options: { baseURL: "http://localhost:8787/v1" },
+      models: { "qwen3:8b": { name: "qwen3:8b" } },
+    });
+    expect(config.model).toBe("request-logger/qwen3:8b");
+    expect(config.small_model).toBe("request-logger/qwen3:8b");
+    expect(result.setup).toEqual([]);
+  });
+
+  it("shell-quotes a model ID containing quotes and metacharacters", () => {
+    const model = `model ' "$HOME"; printf INJECTED`;
+    const result = customTarget({
+      agent: "opencode",
+      provider: CUSTOM_ID,
+      customBaseUrl: "http://localhost:11434",
+      customRenderer: "openai",
+      customModel: model,
+    });
+    const assignment = result.command.slice(0, -" opencode".length);
+    const serialized = execFileSync(
+      "/bin/sh",
+      [
+        "-c",
+        `${assignment} node -e 'process.stdout.write(process.env.OPENCODE_CONFIG_CONTENT)'`,
+      ],
+      { encoding: "utf8" }
+    );
+    const config = JSON.parse(serialized);
+
+    expect(config.model).toBe(`request-logger/${model}`);
+    expect(config.provider["request-logger"].models).toEqual({
+      [model]: { name: model },
+    });
+  });
+
+  it("requires a remembered model for specialized OpenCode custom targets", () => {
+    const result = resolveChoice(
+      {
+        agent: "opencode",
+        provider: CUSTOM_ID,
+        customBaseUrl: "http://localhost:11434",
+        customRenderer: "openai",
+      },
+      PORT
+    );
+    expect(result.kind).toBe("error");
+    expect(result.kind === "error" && result.message).toContain("--force");
+  });
+
   it("borrows OpenCode's Anthropic env var and config file for an anthropic-compatible custom target", () => {
     // The env var and the config file both point the agent at the proxy's own
     // address (http://localhost:8787), not at the upstream the student typed
@@ -806,19 +910,23 @@ describe("resolveChoice — custom base URL, per-agent command template", () => 
       customBaseUrl: "http://localhost:11434",
       customRenderer: "anthropic",
     });
-    expect(result.command).toContain("ANTHROPIC_BASE_URL=http://localhost:8787/v1");
+    expect(result.command).toContain(
+      "ANTHROPIC_BASE_URL=http://localhost:8787/v1"
+    );
     expect(result.setup[0].path).toBe("~/.config/opencode/opencode.json");
     expect(result.upstreamBaseUrl).toBe("http://localhost:11434");
   });
 
-  it("borrows OpenCode's OpenAI env var for an openai-compatible custom target", () => {
+  it("uses OpenCode's temporary config for an openai-compatible custom target", () => {
     const result = customTarget({
       agent: "opencode",
       provider: CUSTOM_ID,
       customBaseUrl: "http://localhost:11434",
       customRenderer: "openai",
+      customModel: "test-model",
     });
-    expect(result.command).toContain("OPENAI_BASE_URL=http://localhost:8787/v1");
+    expect(result.command).toContain("OPENCODE_CONFIG_CONTENT=");
+    expect(result.setup).toEqual([]);
   });
 
   it("defaults OpenCode's raw/not-sure custom target to the OpenAI template", () => {
@@ -859,7 +967,9 @@ describe("resolveChoice — custom base URL, per-agent command template", () => 
       customBaseUrl: "http://localhost:11434",
       customRenderer: "raw",
     });
-    expect(result.command).toContain("ANTHROPIC_BASE_URL=http://localhost:8787");
+    expect(result.command).toContain(
+      "ANTHROPIC_BASE_URL=http://localhost:8787"
+    );
     expect(result.command).toContain("claude");
     expect(result.upstreamBaseUrl).toBe("http://localhost:11434");
   });

--- a/request-logger/agents.ts
+++ b/request-logger/agents.ts
@@ -25,8 +25,8 @@ export type RendererId = "anthropic" | "openai" | "gemini" | "raw";
 
 /**
  * What the student picked. This, and only this, is what gets saved to disk —
- * except customBaseUrl and customRenderer, which exist only for a custom
- * target and are the one documented exception. See config.ts.
+ * except the custom target fields, which are the one documented exception.
+ * See config.ts.
  */
 export interface AgentChoice {
   agent: string;
@@ -35,6 +35,8 @@ export interface AgentChoice {
   customBaseUrl?: string;
   /** Only set when provider is CUSTOM_ID: the wire format they chose for it. */
   customRenderer?: RendererId;
+  /** Selected model for OpenCode's custom OpenAI-compatible route. */
+  customModel?: string;
 }
 
 export interface ResolvedTarget {
@@ -109,11 +111,7 @@ export interface SetupRequest {
 }
 
 export type Resolution =
-  | ResolvedTarget
-  | CustomTarget
-  | AgentRefusal
-  | ResolveError
-  | SetupRequest;
+  ResolvedTarget | CustomTarget | AgentRefusal | ResolveError | SetupRequest;
 
 /**
  * The last option in both questions.
@@ -514,7 +512,7 @@ const AGENTS: AgentEntry[] = [
           {
             path: "~/.pi/agent/settings.json",
             language: "json",
-            body: ['{', '  "transport": "sse"', "}"].join("\n"),
+            body: ["{", '  "transport": "sse"', "}"].join("\n"),
           },
         ],
         notes: [
@@ -711,11 +709,18 @@ export function shouldLogRequest(
 
 function buildCommand(provider: ProviderEntry, baseUrl: string): string {
   const fill = (text: string) => text.replace(/\{baseUrl\}/g, baseUrl);
-  const env = (provider.env ?? []).map(([key, value]) => `${key}=${fill(value)}`);
+  const env = (provider.env ?? []).map(
+    ([key, value]) => `${key}=${fill(value)}`
+  );
   // Arguments take the base URL too. Codex has no variable for it, so its
   // whole override arrives as a flag.
   const args = (provider.args ?? []).map(fill);
   return [...env, provider.bin, ...args].join(" ");
+}
+
+/** Quote one complete POSIX shell argument, including embedded single quotes. */
+function shellQuote(value: string): string {
+  return `'${value.replace(/'/g, `'"'"'`)}'`;
 }
 
 /**
@@ -796,6 +801,49 @@ function resolveCustomTarget(
   const renderer: RendererId = choice.customRenderer ?? "raw";
   const template = findCustomTemplate(agent, renderer);
   const baseUrl = `http://localhost:${port}${template?.suffix ?? ""}`;
+
+  if (agent.id === "opencode" && renderer === "openai") {
+    if (!choice.customModel || choice.customModel.trim().length === 0) {
+      return {
+        kind: "error",
+        message:
+          "OpenCode's custom OpenAI-compatible target needs a model ID. " +
+          "Run with --force to choose again.",
+      };
+    }
+
+    const providerId = "request-logger";
+    const selectedModel = `${providerId}/${choice.customModel}`;
+    const config = JSON.stringify({
+      model: selectedModel,
+      small_model: selectedModel,
+      provider: {
+        [providerId]: {
+          npm: "@ai-sdk/openai-compatible",
+          name: "Request Logger",
+          options: { baseURL: baseUrl },
+          models: { [choice.customModel]: { name: choice.customModel } },
+        },
+      },
+    });
+
+    return {
+      kind: "custom-target",
+      agent: agent.id,
+      agentLabel: agent.label,
+      providerLabel: CUSTOM_LABEL,
+      upstreamBaseUrl: upstream.origin,
+      renderer,
+      baseUrl,
+      command: `OPENCODE_CONFIG_CONTENT=${shellQuote(config)} opencode`,
+      setup: [],
+      notes: [
+        "This temporary provider is merged with your existing OpenCode " +
+          "configuration for this run only; your config file is not changed.",
+      ],
+      warnings: [],
+    };
+  }
 
   const notes = [
     `This command is built from ${agent.label}'s own setup pattern, since a ` +

--- a/request-logger/config-wizard.test.ts
+++ b/request-logger/config-wizard.test.ts
@@ -76,7 +76,10 @@ describe("the OpenCode custom OpenAI-compatible model step", () => {
 
   it("accepts required manual input even when discovery succeeded", async () => {
     customOpenCodeAnswers();
-    discoveryMocks.discoverModelIds.mockResolvedValue(["qwen3:8b"]);
+    discoveryMocks.discoverModelIds.mockResolvedValue([
+      "qwen3:8b",
+      "deepseek-r1",
+    ]);
     promptMocks.select.mockImplementationOnce(async (options) => {
       return options.options.at(-1).value;
     });
@@ -90,6 +93,21 @@ describe("the OpenCode custom OpenAI-compatible model step", () => {
     const answer = await askChoice({ offerToRemember: false });
 
     expect(answer.choice.customModel).toBe("model with spaces");
+  });
+
+  it("uses the only discovered model without asking", async () => {
+    customOpenCodeAnswers();
+    discoveryMocks.discoverModelIds.mockResolvedValue(["qwen3:8b"]);
+    // Three prior selects only: agent, "custom", renderer. A fourth select
+    // call here would mean the model step asked anyway.
+    const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
+
+    const answer = await askChoice({ offerToRemember: false });
+
+    expect(promptMocks.select).toHaveBeenCalledTimes(3);
+    expect(answer.choice.customModel).toBe("qwen3:8b");
+    expect(log).toHaveBeenCalledWith(expect.stringContaining("qwen3:8b"));
+    log.mockRestore();
   });
 
   it("warns and immediately requires manual entry when discovery returns no IDs", async () => {

--- a/request-logger/config-wizard.test.ts
+++ b/request-logger/config-wizard.test.ts
@@ -1,0 +1,137 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const promptMocks = vi.hoisted(() => ({
+  cancel: vi.fn(),
+  confirm: vi.fn(),
+  intro: vi.fn(),
+  isCancel: vi.fn(() => false),
+  select: vi.fn(),
+  text: vi.fn(),
+}));
+
+const discoveryMocks = vi.hoisted(() => ({
+  discoverModelIds: vi.fn(),
+}));
+
+vi.mock("@clack/prompts", () => promptMocks);
+vi.mock("./model-discovery", () => discoveryMocks);
+
+import { askChoice } from "./config";
+
+function customOpenCodeAnswers() {
+  promptMocks.select.mockResolvedValueOnce("opencode");
+  promptMocks.select.mockResolvedValueOnce("custom");
+  promptMocks.text.mockResolvedValueOnce("http://localhost:11434");
+  promptMocks.select.mockResolvedValueOnce("openai");
+}
+
+beforeEach(() => {
+  for (const mock of Object.values(promptMocks)) mock.mockReset();
+  discoveryMocks.discoverModelIds.mockReset();
+  promptMocks.isCancel.mockReturnValue(false);
+});
+
+describe("the OpenCode custom OpenAI-compatible model step", () => {
+  it("keeps one generic Custom base URL option and adds no local-provider option", async () => {
+    promptMocks.select.mockResolvedValueOnce("opencode");
+    promptMocks.select.mockImplementationOnce(async (options) => {
+      const labels = options.options.map(
+        (option: { label: string }) => option.label
+      );
+      expect(
+        labels.filter((label: string) => label === "Custom base URL")
+      ).toHaveLength(1);
+      expect(
+        labels.some((label: string) => /local.*provider/i.test(label))
+      ).toBe(false);
+      return "anthropic";
+    });
+
+    await askChoice({ offerToRemember: false });
+
+    expect(discoveryMocks.discoverModelIds).not.toHaveBeenCalled();
+  });
+
+  it("offers discovered models and keeps manual entry as the final option", async () => {
+    customOpenCodeAnswers();
+    discoveryMocks.discoverModelIds.mockResolvedValue([
+      "qwen3:8b",
+      "deepseek-r1",
+    ]);
+    promptMocks.select.mockImplementationOnce(async (options) => {
+      expect(
+        options.options.map((option: { label: string }) => option.label)
+      ).toEqual(["qwen3:8b", "deepseek-r1", "Enter a model ID manually"]);
+      return options.options[0].value;
+    });
+
+    const answer = await askChoice({ offerToRemember: false });
+
+    expect(discoveryMocks.discoverModelIds).toHaveBeenCalledOnce();
+    expect(discoveryMocks.discoverModelIds).toHaveBeenCalledWith(
+      "http://localhost:11434"
+    );
+    expect(answer.choice.customModel).toBe("qwen3:8b");
+  });
+
+  it("accepts required manual input even when discovery succeeded", async () => {
+    customOpenCodeAnswers();
+    discoveryMocks.discoverModelIds.mockResolvedValue(["qwen3:8b"]);
+    promptMocks.select.mockImplementationOnce(async (options) => {
+      return options.options.at(-1).value;
+    });
+    promptMocks.text.mockImplementationOnce(async (options) => {
+      expect(options.validate("")).toBe("A model ID is required.");
+      expect(options.validate("   ")).toBe("A model ID is required.");
+      expect(options.validate("model with spaces")).toBeUndefined();
+      return "  model with spaces  ";
+    });
+
+    const answer = await askChoice({ offerToRemember: false });
+
+    expect(answer.choice.customModel).toBe("model with spaces");
+  });
+
+  it("warns and immediately requires manual entry when discovery returns no IDs", async () => {
+    customOpenCodeAnswers();
+    discoveryMocks.discoverModelIds.mockResolvedValue([]);
+    const warning = vi
+      .spyOn(console, "warn")
+      .mockImplementation(() => undefined);
+    promptMocks.text.mockResolvedValueOnce("fallback-model");
+
+    const answer = await askChoice({ offerToRemember: false });
+
+    expect(warning).toHaveBeenCalledWith(expect.stringContaining("model"));
+    expect(promptMocks.select).toHaveBeenCalledTimes(3);
+    expect(answer.choice.customModel).toBe("fallback-model");
+    warning.mockRestore();
+  });
+
+  it.each(["anthropic", "raw"])(
+    "does not discover models for the %s custom renderer",
+    async (renderer) => {
+      promptMocks.select.mockResolvedValueOnce("opencode");
+      promptMocks.select.mockResolvedValueOnce("custom");
+      promptMocks.text.mockResolvedValueOnce("http://localhost:11434");
+      promptMocks.select.mockResolvedValueOnce(renderer);
+
+      const answer = await askChoice({ offerToRemember: false });
+
+      expect(discoveryMocks.discoverModelIds).not.toHaveBeenCalled();
+      expect(answer.choice.customModel).toBeUndefined();
+    }
+  );
+
+  it("does not discover models for another agent's OpenAI-compatible custom target", async () => {
+    promptMocks.select.mockResolvedValueOnce("codex");
+    promptMocks.select.mockResolvedValueOnce("custom");
+    promptMocks.text.mockResolvedValueOnce("http://localhost:11434");
+    promptMocks.select.mockResolvedValueOnce("openai");
+
+    const answer = await askChoice({ offerToRemember: false });
+
+    expect(discoveryMocks.discoverModelIds).not.toHaveBeenCalled();
+    expect(answer.choice.customModel).toBeUndefined();
+  });
+});

--- a/request-logger/config.test.ts
+++ b/request-logger/config.test.ts
@@ -24,7 +24,10 @@ describe("the remembered answer", () => {
 
   it("reads back an agent that has one provider only", () => {
     saveChoice(file, { agent: "claude-code" });
-    expect(loadChoice(file)).toEqual({ agent: "claude-code", provider: undefined });
+    expect(loadChoice(file)).toEqual({
+      agent: "claude-code",
+      provider: undefined,
+    });
   });
 
   it("reports no answer when the file is not there", () => {
@@ -45,12 +48,14 @@ describe("the remembered answer — the custom base URL exception", () => {
       provider: "custom",
       customBaseUrl: "http://localhost:11434",
       customRenderer: "openai",
+      customModel: "qwen3:8b",
     });
     expect(loadChoice(file)).toEqual({
       agent: "opencode",
       provider: "custom",
       customBaseUrl: "http://localhost:11434",
       customRenderer: "openai",
+      customModel: "qwen3:8b",
     });
   });
 
@@ -77,9 +82,21 @@ describe("the remembered answer — the custom base URL exception", () => {
   it("ignores a non-string customBaseUrl in a damaged or hand-edited file", () => {
     fs.writeFileSync(
       file,
-      JSON.stringify({ agent: "opencode", provider: "custom", customBaseUrl: 42 })
+      JSON.stringify({
+        agent: "opencode",
+        provider: "custom",
+        customBaseUrl: 42,
+      })
     );
     expect(loadChoice(file)?.customBaseUrl).toBeUndefined();
+  });
+
+  it("ignores a non-string customModel in a damaged or hand-edited file", () => {
+    fs.writeFileSync(
+      file,
+      JSON.stringify({ agent: "opencode", provider: "custom", customModel: 42 })
+    );
+    expect(loadChoice(file)?.customModel).toBeUndefined();
   });
 });
 

--- a/request-logger/config.ts
+++ b/request-logger/config.ts
@@ -9,8 +9,9 @@
  *
  * The one documented exception is a custom base URL. It has no catalogue
  * entry to re-derive from — the student typed it — so for that choice only,
- * the base URL and the wire format are saved alongside the agent and
- * provider. Every other choice keeps behaving exactly as described above.
+ * the base URL and wire format are saved alongside the agent and provider.
+ * OpenCode's custom OpenAI-compatible route also saves its selected model.
+ * Every other choice keeps behaving exactly as described above.
  *
  * This is glue, not logic. The decisions all live in agents.ts, which is where
  * the tests are.
@@ -30,6 +31,7 @@ import {
   type AgentChoice,
   type RendererId,
 } from "./agents";
+import { discoverModelIds } from "./model-discovery";
 
 export interface WizardAnswer {
   choice: AgentChoice;
@@ -54,15 +56,20 @@ export function loadChoice(file: string): AgentChoice | null {
     if (typeof parsed?.agent !== "string") return null;
     return {
       agent: parsed.agent,
-      provider: typeof parsed.provider === "string" ? parsed.provider : undefined,
+      provider:
+        typeof parsed.provider === "string" ? parsed.provider : undefined,
       // The one documented exception to "nothing but the choice is saved" —
       // see the module comment above.
       customBaseUrl:
-        typeof parsed.customBaseUrl === "string" ? parsed.customBaseUrl : undefined,
+        typeof parsed.customBaseUrl === "string"
+          ? parsed.customBaseUrl
+          : undefined,
       customRenderer:
         typeof parsed.customRenderer === "string"
           ? (parsed.customRenderer as RendererId)
           : undefined,
+      customModel:
+        typeof parsed.customModel === "string" ? parsed.customModel : undefined,
     };
   } catch {
     return null;
@@ -115,13 +122,17 @@ function stopIfCancelled<T>(value: T | symbol): T {
  * provider question's "Custom base URL" option, and an alwaysCustom agent
  * that skips straight here.
  */
-async function askCustomTarget(): Promise<{ baseUrl: string; renderer: RendererId }> {
+async function askCustomTarget(): Promise<{
+  baseUrl: string;
+  renderer: RendererId;
+}> {
   const baseUrl = stopIfCancelled(
     await text({
       message: "What's the base URL of the model server you want to log?",
       placeholder: "http://localhost:11434",
       validate: (value) => {
-        if (!value || value.trim().length === 0) return "A base URL is required.";
+        if (!value || value.trim().length === 0)
+          return "A base URL is required.";
         try {
           const url = new URL(value.trim());
           if (url.protocol !== "http:" && url.protocol !== "https:") {
@@ -148,6 +159,47 @@ async function askCustomTarget(): Promise<{ baseUrl: string; renderer: RendererI
   return { baseUrl: baseUrl.trim(), renderer };
 }
 
+async function askModelIdManually(): Promise<string> {
+  const model = stopIfCancelled(
+    await text({
+      message: "What's the model ID?",
+      placeholder: "qwen3:8b",
+      validate: (value) =>
+        !value || value.trim().length === 0
+          ? "A model ID is required."
+          : undefined,
+    })
+  );
+  return model.trim();
+}
+
+async function askOpenCodeModel(baseUrl: string): Promise<string> {
+  const modelIds = await discoverModelIds(baseUrl);
+  if (modelIds.length === 0) {
+    console.warn(
+      "[request-logger] Could not discover any models; enter a model ID manually."
+    );
+    return askModelIdManually();
+  }
+
+  type ModelSelection = { kind: "model"; id: string } | { kind: "manual" };
+  const manual: ModelSelection = { kind: "manual" };
+  const selected = stopIfCancelled(
+    await select<ModelSelection>({
+      message: "Which model do you want OpenCode to use?",
+      options: [
+        ...modelIds.map((id) => ({
+          value: { kind: "model" as const, id },
+          label: id,
+        })),
+        { value: manual, label: "Enter a model ID manually" },
+      ],
+    })
+  );
+
+  return selected.kind === "model" ? selected.id : askModelIdManually();
+}
+
 export async function askChoice(options: AskOptions): Promise<WizardAnswer> {
   intro(styleText("bold", " request-logger "));
 
@@ -168,14 +220,16 @@ export async function askChoice(options: AskOptions): Promise<WizardAnswer> {
 
   // "Other" ends the wizard. There is no provider to ask about, and nothing to
   // remember.
-  if (agentId === OTHER_ID) return { choice: { agent: OTHER_ID }, remember: false };
+  if (agentId === OTHER_ID)
+    return { choice: { agent: OTHER_ID }, remember: false };
 
   const agent = agents.find((a) => a.id === agentId);
 
   // An agent that cannot be logged is a dead end. Saving it would only make the
   // student clear the file before they could try a different one, so the
   // question is not asked at all.
-  if (agent && !agent.supported) return { choice: { agent: agentId }, remember: false };
+  if (agent && !agent.supported)
+    return { choice: { agent: agentId }, remember: false };
 
   let choice: AgentChoice;
 
@@ -211,7 +265,10 @@ export async function askChoice(options: AskOptions): Promise<WizardAnswer> {
     );
 
     if (providerId === OTHER_ID) {
-      return { choice: { agent: agentId, provider: OTHER_ID }, remember: false };
+      return {
+        choice: { agent: agentId, provider: OTHER_ID },
+        remember: false,
+      };
     }
 
     if (providerId === CUSTOM_ID) {
@@ -221,6 +278,10 @@ export async function askChoice(options: AskOptions): Promise<WizardAnswer> {
         provider: CUSTOM_ID,
         customBaseUrl: custom.baseUrl,
         customRenderer: custom.renderer,
+        customModel:
+          agentId === "opencode" && custom.renderer === "openai"
+            ? await askOpenCodeModel(custom.baseUrl)
+            : undefined,
       };
     } else {
       choice = { agent: agentId, provider: providerId };

--- a/request-logger/config.ts
+++ b/request-logger/config.ts
@@ -182,6 +182,16 @@ async function askOpenCodeModel(baseUrl: string): Promise<string> {
     return askModelIdManually();
   }
 
+  // Exactly one candidate is not a choice — there is nothing to pick between,
+  // so asking would only be a confirmation click. Two or more is a real
+  // choice (which local model? which quantization?) and stays interactive, so
+  // the student is never silently pointed at a model they did not mean to
+  // use.
+  if (modelIds.length === 1) {
+    console.log(`[request-logger] Using the only model found: ${modelIds[0]}`);
+    return modelIds[0];
+  }
+
   type ModelSelection = { kind: "model"; id: string } | { kind: "manual" };
   const manual: ModelSelection = { kind: "manual" };
   const selected = stopIfCancelled(

--- a/request-logger/model-discovery.test.ts
+++ b/request-logger/model-discovery.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it, vi } from "vitest";
+import { discoverModelIds, parseModelIds } from "./model-discovery";
+
+describe("parseModelIds", () => {
+  it("parses model IDs from a standard OpenAI-compatible response", () => {
+    expect(
+      parseModelIds({ data: [{ id: "qwen3:8b" }, { id: "deepseek-r1" }] })
+    ).toEqual(["qwen3:8b", "deepseek-r1"]);
+  });
+
+  it("ignores entries without usable string IDs", () => {
+    expect(
+      parseModelIds({
+        data: [{ id: "qwen3:8b" }, {}, { id: 42 }, { id: "" }, { id: "   " }],
+      })
+    ).toEqual(["qwen3:8b"]);
+  });
+
+  it.each([null, {}, { data: {} }])(
+    "returns no IDs for malformed data: %j",
+    (body) => {
+      expect(parseModelIds(body)).toEqual([]);
+    }
+  );
+});
+
+describe("discoverModelIds", () => {
+  it("queries the custom origin's /v1/models endpoint once without credentials", async () => {
+    const fetchImpl = vi.fn().mockResolvedValue(
+      new Response(JSON.stringify({ data: [{ id: "local-model" }] }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      })
+    );
+
+    await expect(
+      discoverModelIds("http://localhost:11434/a/path", { fetchImpl })
+    ).resolves.toEqual(["local-model"]);
+
+    expect(fetchImpl).toHaveBeenCalledOnce();
+    const [url, init] = fetchImpl.mock.calls[0];
+    expect(url).toBe("http://localhost:11434/v1/models");
+    expect(init).not.toHaveProperty("headers");
+    expect(init.signal).toBeInstanceOf(AbortSignal);
+  });
+
+  it.each([
+    ["network failure", () => Promise.reject(new Error("offline"))],
+    [
+      "unsuccessful status",
+      () => Promise.resolve(new Response("no", { status: 500 })),
+    ],
+    ["malformed JSON", () => Promise.resolve(new Response("not json"))],
+  ])("falls back to no IDs after %s", async (_name, implementation) => {
+    await expect(
+      discoverModelIds("http://localhost:11434", {
+        fetchImpl: vi.fn(implementation),
+      })
+    ).resolves.toEqual([]);
+  });
+
+  it("aborts discovery after the configured timeout and falls back to no IDs", async () => {
+    vi.useFakeTimers();
+    const fetchImpl = vi.fn((_url: RequestInfo | URL, init?: RequestInit) => {
+      return new Promise<Response>((_resolve, reject) => {
+        init?.signal?.addEventListener("abort", () =>
+          reject(init.signal?.reason)
+        );
+      });
+    });
+
+    const result = discoverModelIds("http://localhost:11434", {
+      fetchImpl,
+      timeoutMs: 25,
+    });
+    await vi.advanceTimersByTimeAsync(25);
+
+    await expect(result).resolves.toEqual([]);
+    vi.useRealTimers();
+  });
+});

--- a/request-logger/model-discovery.ts
+++ b/request-logger/model-discovery.ts
@@ -1,0 +1,53 @@
+/** OpenAI-compatible model discovery for the narrow OpenCode custom-target flow. */
+
+export const MODEL_DISCOVERY_TIMEOUT_MS = 3_000;
+
+export function parseModelIds(body: unknown): string[] {
+  if (
+    typeof body !== "object" ||
+    body === null ||
+    !("data" in body) ||
+    !Array.isArray(body.data)
+  ) {
+    return [];
+  }
+
+  const ids = body.data.flatMap((entry): string[] => {
+    if (
+      typeof entry !== "object" ||
+      entry === null ||
+      !("id" in entry) ||
+      typeof entry.id !== "string" ||
+      entry.id.trim().length === 0
+    ) {
+      return [];
+    }
+    return [entry.id];
+  });
+
+  return [...new Set(ids)];
+}
+
+interface DiscoverOptions {
+  fetchImpl?: typeof fetch;
+  timeoutMs?: number;
+}
+
+export async function discoverModelIds(
+  baseUrl: string,
+  options: DiscoverOptions = {}
+): Promise<string[]> {
+  const fetchImpl = options.fetchImpl ?? fetch;
+  const timeoutMs = options.timeoutMs ?? MODEL_DISCOVERY_TIMEOUT_MS;
+
+  try {
+    const origin = new URL(baseUrl).origin;
+    const response = await fetchImpl(`${origin}/v1/models`, {
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+    if (!response.ok) return [];
+    return parseModelIds(await response.json());
+  } catch {
+    return [];
+  }
+}

--- a/request-logger/proxy.test.ts
+++ b/request-logger/proxy.test.ts
@@ -39,6 +39,7 @@ describe("upstreamConnection", () => {
         provider: "custom",
         customBaseUrl: "https://api.deepseek.com",
         customRenderer: "openai",
+        customModel: "test-model",
       },
       PORT
     );


### PR DESCRIPTION
I wanted to make the existing custom base URL flow easier to use with OpenCode and self-hosted OpenAI-compatible models. This PR adds support for this.

When you run `npm run request-logger -- --force` and choose OpenCode, Custom base URL, and OpenAI-compatible, it queries the model provider’s `/v1/models` endpoint and lets you pick an available model. You can also enter a model ID manually, and it falls back to manual entry if discovery fails.

It then generates an ephemeral OpenCode configuration block, telling you to run a command like this, so you can avoid polluting your normal config:

```sh
OPENCODE_CONFIG_CONTENT='{"model":"request-logger/qwen3.8:27b","small_model":"request-logger/qwen3.8:27b","provider":{"request-logger":{"npm":"@ai-sdk/openai-compatible","name":"Request Logger","options":{"baseURL":"http://localhost:8787/v1"},"models":{"qwen3.8:27b":{"name":"qwen3.8:27b"}}}}}' opencode
```

If you remember the setup, the selected model is saved along with the custom base URL and wire format, so future runs do not need to perform discovery again.

Model discovery is unauthenticated, so providers that require credentials for /v1/models need manual model entry.

Here's what it looks like:

https://github.com/user-attachments/assets/ca1f585a-36f7-4d84-a7c6-c3bcec4bf395



