### PR TITLE
request-logger: extend model discovery to Pi's custom base URL route

### DIFF
--- a/request-logger/README.md
+++ b/request-logger/README.md
@@ -57,6 +57,11 @@ Endpoints that require credentials for model listing are not supported.
   offering its built-in model names (`gpt-4o`, and the like), which almost
   never exist on a custom server — the agent would start but every turn would
   fail.
+- Pi asks for a model on every wire format, including Anthropic-compatible —
+  but discovery itself only ever checks the OpenAI-style `/v1/models` listing
+  endpoint, which an Anthropic-compatible server often does not expose. If
+  discovery finds nothing there, that is expected, and typing the model ID by
+  hand is the normal path, not a sign something is broken.
 
 To change a remembered answer:
 

--- a/request-logger/README.md
+++ b/request-logger/README.md
@@ -42,13 +42,21 @@ If you are not sure, pick "not sure". The tool still logs everything; it just
 shows you the raw JSON instead of a fully readable render, because it cannot
 safely guess a shape you did not tell it. See "What you get" below.
 
-For **OpenCode** with an **OpenAI-compatible** custom target, the wizard also
-tries the unauthenticated `/v1/models` endpoint and offers any model IDs it
-finds. You can always enter an ID manually, and the wizard falls back to manual
-entry if discovery fails. Endpoints that require credentials for model listing
-are not supported. The printed command uses a temporary
-`OPENCODE_CONFIG_CONTENT` provider for that one run, merged with your existing
-OpenCode configuration without editing its file.
+For **OpenCode** with an **OpenAI-compatible** custom target, and for **every**
+**Pi** custom target, the wizard also tries the unauthenticated `/v1/models`
+endpoint and offers any model IDs it finds. You can always enter an ID
+manually, and the wizard falls back to manual entry if discovery fails.
+Endpoints that require credentials for model listing are not supported.
+
+- OpenCode's printed command uses a temporary `OPENCODE_CONFIG_CONTENT`
+  provider for that one run, merged with your existing OpenCode configuration
+  without editing its file.
+- Pi has no such temporary option, so the selected model is written into
+  `~/.pi/agent/models.json` alongside the base URL, replacing that provider's
+  built-in model list with the one you chose. Without this, Pi would keep
+  offering its built-in model names (`gpt-4o`, and the like), which almost
+  never exist on a custom server — the agent would start but every turn would
+  fail.
 
 To change a remembered answer:
 
@@ -74,10 +82,11 @@ you having to clear anything.
 The one exception is a **Custom base URL** answer. There is no catalogue entry
 for it to be worked out from — you typed it — so the base URL and the wire
 format you chose are saved in the file too, alongside your choice. OpenCode's
-OpenAI-compatible custom route also saves the selected model ID, so a remembered
-choice starts without repeating discovery. Everything else about a custom
-answer still behaves the same way: change it any time with `--force`, and it is
-never kept for an agent that cannot be logged.
+OpenAI-compatible custom route, and every Pi custom route, also save the
+selected model ID, so a remembered choice starts without repeating discovery.
+Everything else about a custom answer still behaves the same way: change it
+any time with `--force`, and it is never kept for an agent that cannot be
+logged.
 
 ## The agents
 

--- a/request-logger/agents.test.ts
+++ b/request-logger/agents.test.ts
@@ -939,12 +939,13 @@ describe("resolveChoice — custom base URL, per-agent command template", () => 
     expect(result.command).toContain("OPENAI_BASE_URL=");
   });
 
-  it("borrows Pi's OpenAI models file for an openai-compatible custom target", () => {
+  it("borrows Pi's OpenAI provider key for an openai-compatible custom target", () => {
     const result = customTarget({
       agent: "pi",
       provider: CUSTOM_ID,
       customBaseUrl: "http://localhost:11434",
       customRenderer: "openai",
+      customModel: "qwen3:8b",
     });
     expect(result.setup[0].body).toContain('"openai"');
     expect(result.setup[0].body).not.toContain('"openai-codex"');
@@ -956,8 +957,77 @@ describe("resolveChoice — custom base URL, per-agent command template", () => 
       provider: CUSTOM_ID,
       customBaseUrl: "http://localhost:11434",
       customRenderer: "openai",
+      customModel: "qwen3:8b",
     });
     expect(result.setup).toHaveLength(1);
+  });
+
+  it("requires a remembered model for every Pi custom target, not just one wire format", () => {
+    for (const customRenderer of ["openai", "anthropic", "raw"] as const) {
+      const result = resolveChoice(
+        {
+          agent: "pi",
+          provider: CUSTOM_ID,
+          customBaseUrl: "http://localhost:11434",
+          customRenderer,
+        },
+        PORT
+      );
+      expect(result.kind).toBe("error");
+      expect(result.kind === "error" && result.message).toContain("--force");
+    }
+  });
+
+  it("writes the selected model into Pi's models file, replacing its built-in catalogue", () => {
+    const result = customTarget({
+      agent: "pi",
+      provider: CUSTOM_ID,
+      customBaseUrl: "http://localhost:11434",
+      customRenderer: "openai",
+      customModel: "qwen3:8b",
+    });
+    const written = JSON.parse(result.setup[0].body);
+    expect(written.providers.openai).toEqual({
+      baseUrl: "http://localhost:8787/v1",
+      models: [{ id: "qwen3:8b" }],
+    });
+  });
+
+  it("writes Pi's Anthropic provider key for an anthropic-compatible custom target, with the selected model", () => {
+    const result = customTarget({
+      agent: "pi",
+      provider: CUSTOM_ID,
+      customBaseUrl: "http://localhost:11434",
+      customRenderer: "anthropic",
+      customModel: "llama3.1:8b",
+    });
+    const written = JSON.parse(result.setup[0].body);
+    expect(written.providers.anthropic).toEqual({
+      baseUrl: "http://localhost:8787",
+      models: [{ id: "llama3.1:8b" }],
+    });
+  });
+
+  it("gives Pi a bare command for a custom target too, since Pi has no base URL variable", () => {
+    const result = customTarget({
+      agent: "pi",
+      provider: CUSTOM_ID,
+      customBaseUrl: "http://localhost:11434",
+      customRenderer: "openai",
+      customModel: "qwen3:8b",
+    });
+    expect(result.command).toBe("pi");
+  });
+
+  it("does not carry Pi's built-in-catalogue note into a custom target, since that note is no longer true there", () => {
+    const result = customTarget({
+      agent: "pi",
+      provider: CUSTOM_ID,
+      customBaseUrl: "http://localhost:11434",
+      customRenderer: "openai",
+      customModel: "qwen3:8b",
+    });
+    expect(result.notes.join(" ")).not.toContain("whole built-in model list");
   });
 
   it("reuses Claude Code's own template regardless of the wire format chosen, since it has only one", () => {

--- a/request-logger/agents.test.ts
+++ b/request-logger/agents.test.ts
@@ -3,6 +3,7 @@ import { execFileSync } from "node:child_process";
 import {
   agentProviders,
   CUSTOM_ID,
+  customTargetNeedsModel,
   ISSUE_URL,
   listAgents,
   listProviders,
@@ -1008,6 +1009,28 @@ describe("resolveChoice — custom base URL, per-agent command template", () => 
     });
   });
 
+  it("warns an Anthropic-compatible Pi custom target that discovery may find nothing, since /v1/models is OpenAI-shaped", () => {
+    const result = customTarget({
+      agent: "pi",
+      provider: CUSTOM_ID,
+      customBaseUrl: "http://localhost:11434",
+      customRenderer: "anthropic",
+      customModel: "llama3.1:8b",
+    });
+    expect(result.notes.join(" ")).toContain("/v1/models");
+  });
+
+  it("gives an openai-compatible Pi custom target no discovery caveat, since that is exactly what discovery checks", () => {
+    const result = customTarget({
+      agent: "pi",
+      provider: CUSTOM_ID,
+      customBaseUrl: "http://localhost:11434",
+      customRenderer: "openai",
+      customModel: "qwen3:8b",
+    });
+    expect(result.notes.join(" ")).not.toContain("/v1/models");
+  });
+
   it("gives Pi a bare command for a custom target too, since Pi has no base URL variable", () => {
     const result = customTarget({
       agent: "pi",
@@ -1063,6 +1086,28 @@ describe("resolveChoice — custom base URL, per-agent command template", () => 
     });
     expect(result.command).not.toContain("/backend-api/codex");
     expect(result.baseUrl).toBe("http://localhost:8787/v1");
+  });
+});
+
+describe("customTargetNeedsModel", () => {
+  it("needs a model for Pi on every wire format", () => {
+    expect(customTargetNeedsModel("pi", "openai")).toBe(true);
+    expect(customTargetNeedsModel("pi", "anthropic")).toBe(true);
+    expect(customTargetNeedsModel("pi", "raw")).toBe(true);
+  });
+
+  it("needs a model for OpenCode only on the OpenAI-compatible wire format", () => {
+    expect(customTargetNeedsModel("opencode", "openai")).toBe(true);
+    expect(customTargetNeedsModel("opencode", "anthropic")).toBe(false);
+    expect(customTargetNeedsModel("opencode", "raw")).toBe(false);
+  });
+
+  it("needs no model for any other agent, on any wire format", () => {
+    for (const renderer of ["openai", "anthropic", "raw"] as const) {
+      expect(customTargetNeedsModel("codex", renderer)).toBe(false);
+      expect(customTargetNeedsModel("claude-code", renderer)).toBe(false);
+      expect(customTargetNeedsModel("omp", renderer)).toBe(false);
+    }
   });
 });
 

--- a/request-logger/agents.ts
+++ b/request-logger/agents.ts
@@ -35,7 +35,11 @@ export interface AgentChoice {
   customBaseUrl?: string;
   /** Only set when provider is CUSTOM_ID: the wire format they chose for it. */
   customRenderer?: RendererId;
-  /** Selected model for OpenCode's custom OpenAI-compatible route. */
+  /**
+   * Selected model for a custom target that needs one declared up front:
+   * OpenCode's custom OpenAI-compatible route, and any of Pi's custom
+   * routes (see resolveCustomTarget).
+   */
   customModel?: string;
 }
 
@@ -228,8 +232,19 @@ const PI_NOTE =
  * Pi's provider override file. The key is `baseUrl`, in this exact spelling.
  * Pi accepts other spellings into the file and then refuses to start, so this
  * is worth getting right for the student.
+ *
+ * `modelId`, when given, is written as a one-entry `models` array under the
+ * same provider. Pi replaces that provider's whole built-in model catalogue
+ * with whatever `models` lists — see resolveCustomTarget's Pi branch, which
+ * is the only caller that passes it. Omitted, as it is for every catalogue
+ * entry above, Pi keeps its built-in catalogue for that provider, which is
+ * correct there because those routes really do talk to Anthropic or OpenAI.
  */
-function piModels(providerId: string, baseUrl: string): SetupFile {
+function piModels(
+  providerId: string,
+  baseUrl: string,
+  modelId?: string
+): SetupFile {
   return {
     path: "~/.pi/agent/models.json",
     language: "json",
@@ -237,7 +252,8 @@ function piModels(providerId: string, baseUrl: string): SetupFile {
       "{",
       '  "providers": {',
       `    "${providerId}": {`,
-      `      "baseUrl": "${baseUrl}"`,
+      `      "baseUrl": "${baseUrl}"${modelId ? "," : ""}`,
+      ...(modelId ? [`      "models": [{ "id": "${modelId}" }]`] : []),
       "    }",
       "  }",
       "}",
@@ -842,6 +858,58 @@ function resolveCustomTarget(
           "configuration for this run only; your config file is not changed.",
       ],
       warnings: [],
+    };
+  }
+
+  /**
+   * Pi's custom target, on every wire format — unlike OpenCode's branch
+   * above, which only fires for the OpenAI-compatible choice. Pi always
+   * writes a models.json override for a custom base URL (see piModels), and
+   * that override always replaces one of Pi's built-in providers, whose
+   * built-in model names (gpt-4o, claude-*) almost never exist on a
+   * self-hosted backend regardless of which wire format the student picked
+   * for rendering. So a model is required here every time, not just for one
+   * renderer.
+   */
+  if (agent.id === "pi") {
+    if (!choice.customModel || choice.customModel.trim().length === 0) {
+      return {
+        kind: "error",
+        message:
+          "Pi's custom target needs a model ID. Run with --force to choose again.",
+      };
+    }
+
+    // template is the anthropic or openai Pi provider entry (see
+    // findCustomTemplate) — its id is the provider key Pi's built-in
+    // catalogue uses, which is also the key this override replaces.
+    const providerId = template?.id ?? "custom";
+    const notes = [
+      `This models.json entry replaces Pi's built-in "${providerId}" model ` +
+        "catalogue with the one model you selected, since Pi's built-in " +
+        "model names almost never exist on a custom server.",
+    ];
+    if (renderer === "raw") {
+      notes.push(
+        'You picked "not sure" for the wire format, so every capture falls ' +
+          "back to a raw JSON dump instead of a fully rendered one. That is " +
+          "not broken — it is just less readable. Run with --force and pick a " +
+          "format once you know it, and the readable renderer takes over."
+      );
+    }
+
+    return {
+      kind: "custom-target",
+      agent: agent.id,
+      agentLabel: agent.label,
+      providerLabel: CUSTOM_LABEL,
+      upstreamBaseUrl: upstream.origin,
+      renderer,
+      baseUrl,
+      command: template ? buildCommand(template, baseUrl) : agent.id,
+      setup: [piModels(providerId, baseUrl, choice.customModel)],
+      notes,
+      warnings: template?.warnings ?? [],
     };
   }
 

--- a/request-logger/agents.ts
+++ b/request-logger/agents.ts
@@ -786,6 +786,65 @@ function findCustomTemplate(
 }
 
 /**
+ * The note shown whenever a custom target's wire format is "raw" — the
+ * student said they were not sure, so every capture falls back to a JSON
+ * dump. Every custom-target route says this the same way, so it is written
+ * once here rather than copied into each one.
+ */
+const RAW_WIRE_FORMAT_NOTE =
+  'You picked "not sure" for the wire format, so every capture falls ' +
+  "back to a raw JSON dump instead of a fully rendered one. That is " +
+  "not broken — it is just less readable. Run with --force and pick a " +
+  "format once you know it, and the readable renderer takes over.";
+
+/**
+ * Whether a custom target for this agent and wire format needs a model
+ * declared up front, rather than being able to start against a bare base
+ * URL. The single source of truth both the wizard (config.ts, deciding
+ * whether to bother discovering one) and resolveCustomTarget (deciding
+ * whether to require one) consult, so a third agent that needs this only
+ * ever means one edit, here.
+ *
+ * - OpenCode only needs one for its OpenAI-compatible route: that is the
+ *   one built from an ephemeral provider with no catalogue entry to borrow
+ *   a model from. Its Anthropic-compatible route borrows a real Anthropic
+ *   provider instead, whose model names are real Anthropic model names.
+ * - Pi needs one on every route: every one of its custom targets overrides
+ *   an existing built-in provider (openai or anthropic), and that
+ *   provider's built-in model names almost never exist on a self-hosted
+ *   backend, whichever wire format was chosen for rendering.
+ */
+export function customTargetNeedsModel(
+  agentId: string,
+  renderer: RendererId
+): boolean {
+  if (agentId === "pi") return true;
+  if (agentId === "opencode") return renderer === "openai";
+  return false;
+}
+
+/**
+ * Read the model the wizard asked for, or the error both routes that need
+ * one return when it is missing — a remembered choice saved before this
+ * field existed, say, or one edited by hand. Shared so the two routes that
+ * call customTargetNeedsModel report the same shape of error, differing
+ * only in which target they name.
+ */
+function resolveCustomModel(
+  choice: AgentChoice,
+  targetLabel: string
+): { kind: "model"; model: string } | ResolveError {
+  const model = choice.customModel?.trim();
+  if (!model) {
+    return {
+      kind: "error",
+      message: `${targetLabel} needs a model ID. Run with --force to choose again.`,
+    };
+  }
+  return { kind: "model", model };
+}
+
+/**
  * Build a target from what the student typed, in place of a catalogue
  * lookup. The only facts on hand are the base URL and the wire format they
  * chose; everything else is borrowed from the closest matching catalogue
@@ -818,18 +877,16 @@ function resolveCustomTarget(
   const template = findCustomTemplate(agent, renderer);
   const baseUrl = `http://localhost:${port}${template?.suffix ?? ""}`;
 
-  if (agent.id === "opencode" && renderer === "openai") {
-    if (!choice.customModel || choice.customModel.trim().length === 0) {
-      return {
-        kind: "error",
-        message:
-          "OpenCode's custom OpenAI-compatible target needs a model ID. " +
-          "Run with --force to choose again.",
-      };
-    }
+  if (agent.id === "opencode" && customTargetNeedsModel(agent.id, renderer)) {
+    const modelResult = resolveCustomModel(
+      choice,
+      "OpenCode's custom OpenAI-compatible target"
+    );
+    if (modelResult.kind === "error") return modelResult;
+    const { model } = modelResult;
 
     const providerId = "request-logger";
-    const selectedModel = `${providerId}/${choice.customModel}`;
+    const selectedModel = `${providerId}/${model}`;
     const config = JSON.stringify({
       model: selectedModel,
       small_model: selectedModel,
@@ -838,7 +895,7 @@ function resolveCustomTarget(
           npm: "@ai-sdk/openai-compatible",
           name: "Request Logger",
           options: { baseURL: baseUrl },
-          models: { [choice.customModel]: { name: choice.customModel } },
+          models: { [model]: { name: model } },
         },
       },
     });
@@ -871,32 +928,41 @@ function resolveCustomTarget(
    * for rendering. So a model is required here every time, not just for one
    * renderer.
    */
-  if (agent.id === "pi") {
-    if (!choice.customModel || choice.customModel.trim().length === 0) {
+  if (agent.id === "pi" && customTargetNeedsModel(agent.id, renderer)) {
+    const modelResult = resolveCustomModel(choice, "Pi's custom target");
+    if (modelResult.kind === "error") return modelResult;
+    const { model } = modelResult;
+
+    // template is the anthropic or openai Pi provider entry (see
+    // findCustomTemplate). Every renderer this branch can be reached with
+    // ("openai", "anthropic", "raw") has a Pi provider tagged for it — see
+    // the catalogue above — so this can only be missing if a future wire
+    // format is added there without a matching Pi template.
+    if (!template) {
       return {
         kind: "error",
         message:
-          "Pi's custom target needs a model ID. Run with --force to choose again.",
+          `Pi has no custom-target template for the "${renderer}" wire ` +
+          `format. Run with --force to choose again.`,
       };
     }
-
-    // template is the anthropic or openai Pi provider entry (see
-    // findCustomTemplate) — its id is the provider key Pi's built-in
-    // catalogue uses, which is also the key this override replaces.
-    const providerId = template?.id ?? "custom";
+    // template.id is the provider key Pi's built-in catalogue uses, which
+    // is also the key this override replaces.
+    const providerId = template.id;
     const notes = [
       `This models.json entry replaces Pi's built-in "${providerId}" model ` +
         "catalogue with the one model you selected, since Pi's built-in " +
         "model names almost never exist on a custom server.",
     ];
-    if (renderer === "raw") {
+    if (renderer === "anthropic") {
       notes.push(
-        'You picked "not sure" for the wire format, so every capture falls ' +
-          "back to a raw JSON dump instead of a fully rendered one. That is " +
-          "not broken — it is just less readable. Run with --force and pick a " +
-          "format once you know it, and the readable renderer takes over."
+        "Model discovery only checks the OpenAI-style /v1/models listing " +
+          "endpoint, which an Anthropic-compatible server often does not " +
+          "expose. If discovery found nothing here and you typed the model " +
+          "ID by hand, that is expected — it does not mean the ID is wrong."
       );
     }
+    if (renderer === "raw") notes.push(RAW_WIRE_FORMAT_NOTE);
 
     return {
       kind: "custom-target",
@@ -906,10 +972,10 @@ function resolveCustomTarget(
       upstreamBaseUrl: upstream.origin,
       renderer,
       baseUrl,
-      command: template ? buildCommand(template, baseUrl) : agent.id,
-      setup: [piModels(providerId, baseUrl, choice.customModel)],
+      command: buildCommand(template, baseUrl),
+      setup: [piModels(providerId, baseUrl, model)],
       notes,
-      warnings: template?.warnings ?? [],
+      warnings: template.warnings ?? [],
     };
   }
 
@@ -919,14 +985,7 @@ function resolveCustomTarget(
       `a specific login or account, it may not apply to your target.`,
     ...(template?.notes ?? []),
   ];
-  if (renderer === "raw") {
-    notes.push(
-      'You picked "not sure" for the wire format, so every capture falls ' +
-        "back to a raw JSON dump instead of a fully rendered one. That is " +
-        "not broken — it is just less readable. Run with --force and pick a " +
-        "format once you know it, and the readable renderer takes over."
-    );
-  }
+  if (renderer === "raw") notes.push(RAW_WIRE_FORMAT_NOTE);
 
   return {
     kind: "custom-target",

--- a/request-logger/config-wizard.test.ts
+++ b/request-logger/config-wizard.test.ts
@@ -25,6 +25,13 @@ function customOpenCodeAnswers() {
   promptMocks.select.mockResolvedValueOnce("openai");
 }
 
+function customPiAnswers(renderer: "openai" | "anthropic" | "raw" = "openai") {
+  promptMocks.select.mockResolvedValueOnce("pi");
+  promptMocks.select.mockResolvedValueOnce("custom");
+  promptMocks.text.mockResolvedValueOnce("http://localhost:11434");
+  promptMocks.select.mockResolvedValueOnce(renderer);
+}
+
 beforeEach(() => {
   for (const mock of Object.values(promptMocks)) mock.mockReset();
   discoveryMocks.discoverModelIds.mockReset();
@@ -146,6 +153,82 @@ describe("the OpenCode custom OpenAI-compatible model step", () => {
     promptMocks.select.mockResolvedValueOnce("custom");
     promptMocks.text.mockResolvedValueOnce("http://localhost:11434");
     promptMocks.select.mockResolvedValueOnce("openai");
+
+    const answer = await askChoice({ offerToRemember: false });
+
+    expect(discoveryMocks.discoverModelIds).not.toHaveBeenCalled();
+    expect(answer.choice.customModel).toBeUndefined();
+  });
+});
+
+describe("the Pi custom-target model step", () => {
+  it.each(["openai", "anthropic", "raw"] as const)(
+    "discovers models for the %s custom renderer too, unlike OpenCode",
+    async (renderer) => {
+      customPiAnswers(renderer);
+      discoveryMocks.discoverModelIds.mockResolvedValue(["qwen3:8b"]);
+      const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
+
+      const answer = await askChoice({ offerToRemember: false });
+
+      expect(discoveryMocks.discoverModelIds).toHaveBeenCalledWith(
+        "http://localhost:11434"
+      );
+      expect(answer.choice.customModel).toBe("qwen3:8b");
+      log.mockRestore();
+    }
+  );
+
+  it("offers discovered models and keeps manual entry as the final option", async () => {
+    customPiAnswers("openai");
+    discoveryMocks.discoverModelIds.mockResolvedValue([
+      "qwen3:8b",
+      "deepseek-r1",
+    ]);
+    promptMocks.select.mockImplementationOnce(async (options) => {
+      expect(
+        options.options.map((option: { label: string }) => option.label)
+      ).toEqual(["qwen3:8b", "deepseek-r1", "Enter a model ID manually"]);
+      return options.options[0].value;
+    });
+
+    const answer = await askChoice({ offerToRemember: false });
+
+    expect(answer.choice.customModel).toBe("qwen3:8b");
+  });
+
+  it("uses the only discovered model without asking", async () => {
+    customPiAnswers("anthropic");
+    discoveryMocks.discoverModelIds.mockResolvedValue(["llama3.1:8b"]);
+    // Three prior selects only: agent, "custom", renderer. A fourth select
+    // call here would mean the model step asked anyway.
+    const log = vi.spyOn(console, "log").mockImplementation(() => undefined);
+
+    const answer = await askChoice({ offerToRemember: false });
+
+    expect(promptMocks.select).toHaveBeenCalledTimes(3);
+    expect(answer.choice.customModel).toBe("llama3.1:8b");
+    log.mockRestore();
+  });
+
+  it("warns and immediately requires manual entry when discovery returns no IDs", async () => {
+    customPiAnswers("openai");
+    discoveryMocks.discoverModelIds.mockResolvedValue([]);
+    const warning = vi
+      .spyOn(console, "warn")
+      .mockImplementation(() => undefined);
+    promptMocks.text.mockResolvedValueOnce("fallback-model");
+
+    const answer = await askChoice({ offerToRemember: false });
+
+    expect(warning).toHaveBeenCalledWith(expect.stringContaining("model"));
+    expect(answer.choice.customModel).toBe("fallback-model");
+    warning.mockRestore();
+  });
+
+  it("does not discover models when Pi is not on a custom target", async () => {
+    promptMocks.select.mockResolvedValueOnce("pi");
+    promptMocks.select.mockResolvedValueOnce("anthropic");
 
     const answer = await askChoice({ offerToRemember: false });
 

--- a/request-logger/config.ts
+++ b/request-logger/config.ts
@@ -25,6 +25,7 @@ import {
   agentProviders,
   CUSTOM_ID,
   CUSTOM_LABEL,
+  customTargetNeedsModel,
   listAgents,
   OTHER_ID,
   OTHER_LABEL,
@@ -296,11 +297,9 @@ export async function askChoice(options: AskOptions): Promise<WizardAnswer> {
         provider: CUSTOM_ID,
         customBaseUrl: custom.baseUrl,
         customRenderer: custom.renderer,
-        customModel:
-          (agentId === "opencode" && custom.renderer === "openai") ||
-          agentId === "pi"
-            ? await askDiscoveredModel(custom.baseUrl)
-            : undefined,
+        customModel: customTargetNeedsModel(agentId, custom.renderer)
+          ? await askDiscoveredModel(custom.baseUrl)
+          : undefined,
       };
     } else {
       choice = { agent: agentId, provider: providerId };

--- a/request-logger/config.ts
+++ b/request-logger/config.ts
@@ -10,8 +10,9 @@
  * The one documented exception is a custom base URL. It has no catalogue
  * entry to re-derive from — the student typed it — so for that choice only,
  * the base URL and wire format are saved alongside the agent and provider.
- * OpenCode's custom OpenAI-compatible route also saves its selected model.
- * Every other choice keeps behaving exactly as described above.
+ * OpenCode's custom OpenAI-compatible route, and every one of Pi's custom
+ * routes, also save their selected model. Every other choice keeps behaving
+ * exactly as described above.
  *
  * This is glue, not logic. The decisions all live in agents.ts, which is where
  * the tests are.
@@ -173,7 +174,14 @@ async function askModelIdManually(): Promise<string> {
   return model.trim();
 }
 
-async function askOpenCodeModel(baseUrl: string): Promise<string> {
+/**
+ * Discover the model IDs a custom base URL serves, and ask which one to use
+ * when there is a real choice — shared by every custom target that needs a
+ * model declared up front: OpenCode's custom OpenAI-compatible route, and
+ * every one of Pi's custom routes. Same shape both times: discover, offer a
+ * choice when there is more than one candidate, fall back to manual entry.
+ */
+async function askDiscoveredModel(baseUrl: string): Promise<string> {
   const modelIds = await discoverModelIds(baseUrl);
   if (modelIds.length === 0) {
     console.warn(
@@ -196,7 +204,7 @@ async function askOpenCodeModel(baseUrl: string): Promise<string> {
   const manual: ModelSelection = { kind: "manual" };
   const selected = stopIfCancelled(
     await select<ModelSelection>({
-      message: "Which model do you want OpenCode to use?",
+      message: "Which model do you want to use?",
       options: [
         ...modelIds.map((id) => ({
           value: { kind: "model" as const, id },
@@ -289,8 +297,9 @@ export async function askChoice(options: AskOptions): Promise<WizardAnswer> {
         customBaseUrl: custom.baseUrl,
         customRenderer: custom.renderer,
         customModel:
-          agentId === "opencode" && custom.renderer === "openai"
-            ? await askOpenCodeModel(custom.baseUrl)
+          (agentId === "opencode" && custom.renderer === "openai") ||
+          agentId === "pi"
+            ? await askDiscoveredModel(custom.baseUrl)
             : undefined,
       };
     } else {

--- a/request-logger/model-discovery.ts
+++ b/request-logger/model-discovery.ts
@@ -1,4 +1,10 @@
-/** OpenAI-compatible model discovery for the narrow OpenCode custom-target flow. */
+/**
+ * OpenAI-compatible model discovery for a custom base URL — the unauthenticated
+ * `/v1/models` listing endpoint most local and third-party model servers
+ * expose. Agent-agnostic on purpose: OpenCode's custom OpenAI-compatible
+ * route and Pi's custom routes both need a real model ID up front, and both
+ * discover it the same way.
+ */
 
 export const MODEL_DISCOVERY_TIMEOUT_MS = 3_000;
 


### PR DESCRIPTION
## Summary

- Pi's custom-target setup overrides an existing built-in provider entry (`openai` or `anthropic`) to point at a student's custom base URL, which lets Pi start — but keeps Pi's built-in model names, which almost never exist on a self-hosted backend, so every turn fails silently.
- Reuse the OpenCode custom-target flow's `discoverModelIds()` in Pi's custom-target wizard step, following the same "discover → offer a choice when there's more than one candidate → fall back to manual entry" shape. Unlike OpenCode's OpenAI-compatible-only trigger, this fires for every Pi custom wire format (openai/anthropic/raw), since Pi always writes the models.json override regardless of renderer.
- `piModels()` now accepts an optional model ID and, when given, writes it as the provider's `models` array in `~/.pi/agent/models.json`, replacing the built-in catalogue instead of relying on it.

Closes #22

## Test plan

- [x] `pnpm test -- request-logger` (236 tests passing, including new coverage for the Pi discovery step in `config-wizard.test.ts` and the models.json output in `agents.test.ts`)
- [x] `pnpm typecheck`
- [x] `npx prettier --check` on all touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)