### PR TITLE
request-logger: print PowerShell-syntax commands on Windows

### DIFF
--- a/request-logger/README.md
+++ b/request-logger/README.md
@@ -79,6 +79,12 @@ To use a different port:
 PORT=9000 npm run request-logger
 ```
 
+On Windows, run that in PowerShell (not Command Prompt) as:
+
+```powershell
+$env:PORT = 9000; npm run request-logger
+```
+
 A remembered answer is kept in `request-logger/.agent-choice.json`, which is
 gitignored. It holds your choice only. The host, the renderer and the command are
 worked out again on every start, so an update to this tool reaches you without
@@ -255,6 +261,13 @@ Be fair to the tool when you judge a failure.
   base URL and wire format mechanism itself is tested directly (see
   `agents.test.ts`); a specific third-party server behind it has not
   necessarily been driven end to end.
+- **Windows is not tested end to end either.** WSL and Git Bash need no
+  special handling — they are POSIX shells, so they use the same command as
+  Mac and Linux. Native PowerShell gets its own `$env:NAME = 'value'` syntax
+  instead (see `withEnv` in `agents.ts`), verified by unit test but not by
+  running a real agent against it on Windows. Command Prompt (`cmd.exe`) is
+  not supported; use PowerShell, which is the default terminal in Windows
+  Terminal and VS Code.
 
 If one of them is wrong, it is worth reporting, and the fix is likely to be one
 line in `agents.ts`.

--- a/request-logger/agents.test.ts
+++ b/request-logger/agents.test.ts
@@ -13,7 +13,7 @@ import {
   type AgentChoice,
 } from "./agents";
 
-const PORT = { port: 8787 };
+const PORT = { port: 8787, platform: "linux" as NodeJS.Platform };
 
 /** Resolve, and fail loudly if the answer was not a usable target. */
 function target(agent: string, provider?: string) {
@@ -321,14 +321,14 @@ describe("resolveChoice — base URLs", () => {
   });
 
   it("uses the port it is given", () => {
-    const result = resolveChoice({ agent: "claude-code" }, { port: 9000 });
+    const result = resolveChoice({ agent: "claude-code" }, { port: 9000, platform: "linux" });
     expect(result.kind === "target" && result.baseUrl).toBe(
       "http://localhost:9000"
     );
   });
 
   it("puts the chosen port into the command", () => {
-    const result = resolveChoice({ agent: "claude-code" }, { port: 9000 });
+    const result = resolveChoice({ agent: "claude-code" }, { port: 9000, platform: "linux" });
     expect(result.kind === "target" && result.command).toContain(
       "http://localhost:9000"
     );
@@ -411,6 +411,58 @@ describe("resolveChoice — commands", () => {
 
   it("gives Pi a bare command, because Pi has no base URL variable", () => {
     expect(target("pi", "anthropic").command).toBe("pi");
+  });
+});
+
+describe("resolveChoice — commands on win32", () => {
+  // A student on native Windows (not WSL, not Git Bash) has no shell that
+  // understands `KEY=value bin` — PowerShell reports it as an unrecognized
+  // command, which is exactly the report that prompted this. PowerShell's
+  // own syntax is one `$env:KEY = 'value'` statement per variable, chained
+  // with semicolons.
+  const WIN = { port: 8787, platform: "win32" as NodeJS.Platform };
+
+  function winTarget(agent: string, provider?: string) {
+    const result = resolveChoice({ agent, provider }, WIN);
+    if (result.kind !== "target") {
+      throw new Error(
+        `expected a target for ${agent}/${provider}, got ${result.kind}`
+      );
+    }
+    return result;
+  }
+
+  it("uses PowerShell $env: syntax instead of POSIX VAR=value", () => {
+    expect(winTarget("claude-code").command).toBe(
+      "$env:ANTHROPIC_BASE_URL = 'http://localhost:8787'; " +
+        "$env:ENABLE_TOOL_SEARCH = 'true'; claude"
+    );
+  });
+
+  it("never prints the POSIX VAR=value form on win32", () => {
+    expect(winTarget("claude-code").command).not.toMatch(
+      /^ANTHROPIC_BASE_URL=/
+    );
+  });
+
+  it("chains one assignment per variable with semicolons", () => {
+    expect(winTarget("copilot").command).toBe(
+      "$env:COPILOT_API_URL = 'http://localhost:8787'; copilot"
+    );
+  });
+
+  it("leaves a command with no env vars unchanged, since there is nothing to rewrite", () => {
+    // Pi has no base URL variable at all.
+    expect(winTarget("pi", "anthropic").command).toBe("pi");
+  });
+
+  it("leaves Codex's flag-based override unchanged", () => {
+    // Codex has no env var override — its whole command is a `-c` flag,
+    // single-quoted. PowerShell parses a single-quoted literal the same way
+    // bash does (no interpolation), so this needs no rewriting.
+    expect(winTarget("codex", "openai").command).toBe(
+      `codex -c 'openai_base_url="http://localhost:8787/v1"'`
+    );
   });
 });
 
@@ -918,6 +970,24 @@ describe("resolveChoice — custom base URL, per-agent command template", () => 
     expect(result.upstreamBaseUrl).toBe("http://localhost:11434");
   });
 
+  it("uses PowerShell syntax for a borrowed-template custom target on win32", () => {
+    const result = resolveChoice(
+      {
+        agent: "opencode",
+        provider: CUSTOM_ID,
+        customBaseUrl: "http://localhost:11434",
+        customRenderer: "anthropic",
+      },
+      { port: 8787, platform: "win32" }
+    );
+    if (result.kind !== "custom-target") {
+      throw new Error(`expected a custom-target, got ${result.kind}`);
+    }
+    expect(result.command).toBe(
+      "$env:ANTHROPIC_BASE_URL = 'http://localhost:8787/v1'; opencode"
+    );
+  });
+
   it("uses OpenCode's temporary config for an openai-compatible custom target", () => {
     const result = customTarget({
       agent: "opencode",
@@ -928,6 +998,45 @@ describe("resolveChoice — custom base URL, per-agent command template", () => 
     });
     expect(result.command).toContain("OPENCODE_CONFIG_CONTENT=");
     expect(result.setup).toEqual([]);
+  });
+
+  it("uses PowerShell syntax for OpenCode's temporary config on win32", () => {
+    const result = resolveChoice(
+      {
+        agent: "opencode",
+        provider: CUSTOM_ID,
+        customBaseUrl: "http://localhost:11434",
+        customRenderer: "openai",
+        customModel: "test-model",
+      },
+      { port: 8787, platform: "win32" }
+    );
+    if (result.kind !== "custom-target") {
+      throw new Error(`expected a custom-target, got ${result.kind}`);
+    }
+    expect(result.command.startsWith("$env:OPENCODE_CONFIG_CONTENT = '")).toBe(
+      true
+    );
+    expect(result.command.endsWith("; opencode")).toBe(true);
+    expect(result.command).not.toContain("OPENCODE_CONFIG_CONTENT=$env");
+    expect(result.command).not.toMatch(/^OPENCODE_CONFIG_CONTENT=/);
+  });
+
+  it("doubles an embedded single quote in the PowerShell-quoted config, since PowerShell has no backslash escape", () => {
+    const result = resolveChoice(
+      {
+        agent: "opencode",
+        provider: CUSTOM_ID,
+        customBaseUrl: "http://localhost:11434",
+        customRenderer: "openai",
+        customModel: `model's name`,
+      },
+      { port: 8787, platform: "win32" }
+    );
+    if (result.kind !== "custom-target") {
+      throw new Error(`expected a custom-target, got ${result.kind}`);
+    }
+    expect(result.command).toContain("model''s name");
   });
 
   it("defaults OpenCode's raw/not-sure custom target to the OpenAI template", () => {

--- a/request-logger/agents.ts
+++ b/request-logger/agents.ts
@@ -723,20 +723,64 @@ export function shouldLogRequest(
 // Resolution — the seam
 // ---------------------------------------------------------------------------
 
-function buildCommand(provider: ProviderEntry, baseUrl: string): string {
+function buildCommand(
+  provider: ProviderEntry,
+  baseUrl: string,
+  platform: NodeJS.Platform
+): string {
   const fill = (text: string) => text.replace(/\{baseUrl\}/g, baseUrl);
   const env = (provider.env ?? []).map(
-    ([key, value]) => `${key}=${fill(value)}`
+    ([key, value]) => [key, fill(value)] as const
   );
   // Arguments take the base URL too. Codex has no variable for it, so its
   // whole override arrives as a flag.
   const args = (provider.args ?? []).map(fill);
-  return [...env, provider.bin, ...args].join(" ");
+  const bin = [provider.bin, ...args].join(" ");
+  return withEnv(env, bin, platform);
+}
+
+/**
+ * Join one or more `KEY=value` environment assignments onto the command that
+ * needs them, in whichever syntax the student's shell actually understands.
+ *
+ * POSIX shells — bash, zsh, and Windows' own WSL and Git Bash — accept
+ * `KEY=value KEY2=value2 bin` directly, so that is the default this tool has
+ * always printed. Windows' native PowerShell has no such syntax at all: typed
+ * back verbatim, it comes back as "is not recognized as a name of a cmdlet"
+ * (the report that prompted this function). PowerShell instead sets each
+ * variable with its own `$env:KEY = 'value'` statement, chained onto one
+ * line with semicolons the way PowerShell joins statements.
+ */
+function withEnv(
+  env: ReadonlyArray<readonly [string, string]>,
+  bin: string,
+  platform: NodeJS.Platform
+): string {
+  if (env.length === 0) return bin;
+  if (platform === "win32") {
+    return [
+      ...env.map(([key, value]) => `$env:${key} = ${powerShellQuote(value)}`),
+      bin,
+    ].join("; ");
+  }
+  return [...env.map(([key, value]) => `${key}=${value}`), bin].join(" ");
 }
 
 /** Quote one complete POSIX shell argument, including embedded single quotes. */
 function shellQuote(value: string): string {
   return `'${value.replace(/'/g, `'"'"'`)}'`;
+}
+
+/**
+ * Quote one complete PowerShell string literal, including embedded single
+ * quotes (PowerShell escapes those by doubling them, not by backslash).
+ * Single-quoted PowerShell strings do no interpolation at all — unlike
+ * double-quoted ones, where a `$` in a base URL or a JSON config would be
+ * read as the start of a variable — so this is the literal, injection-safe
+ * quoting PowerShell offers.
+ */
+function powerShellQuote(value: string): string {
+  return `'${value.replace(/'/g, "''")}'`;
 }
 
 /**
@@ -853,7 +897,8 @@ function resolveCustomModel(
 function resolveCustomTarget(
   agent: AgentEntry,
   choice: AgentChoice,
-  port: number
+  port: number,
+  platform: NodeJS.Platform
 ): Resolution {
   if (!choice.customBaseUrl) {
     return {
@@ -908,7 +953,10 @@ function resolveCustomTarget(
       upstreamBaseUrl: upstream.origin,
       renderer,
       baseUrl,
-      command: `OPENCODE_CONFIG_CONTENT=${shellQuote(config)} opencode`,
+      command:
+        platform === "win32"
+          ? `$env:OPENCODE_CONFIG_CONTENT = ${powerShellQuote(config)}; opencode`
+          : `OPENCODE_CONFIG_CONTENT=${shellQuote(config)} opencode`,
       setup: [],
       notes: [
         "This temporary provider is merged with your existing OpenCode " +
@@ -972,7 +1020,7 @@ function resolveCustomTarget(
       upstreamBaseUrl: upstream.origin,
       renderer,
       baseUrl,
-      command: buildCommand(template, baseUrl),
+      command: buildCommand(template, baseUrl, platform),
       setup: [piModels(providerId, baseUrl, model)],
       notes,
       warnings: template.warnings ?? [],
@@ -995,7 +1043,7 @@ function resolveCustomTarget(
     upstreamBaseUrl: upstream.origin,
     renderer,
     baseUrl,
-    command: template ? buildCommand(template, baseUrl) : agent.id,
+    command: template ? buildCommand(template, baseUrl, platform) : agent.id,
     setup: (template?.setup ?? []).map((file) => ({
       ...file,
       body: file.body.replace(/\{baseUrl\}/g, baseUrl),
@@ -1009,12 +1057,16 @@ function resolveCustomTarget(
  * Turn a saved choice into everything the tool needs, or into a clear reason
  * why it cannot.
  *
- * Pure: no disk, no network, no clock. Give it the same choice and the same
- * port and it gives back the same answer.
+ * Pure: no disk, no network, no clock. Give it the same choice, the same
+ * port and the same platform and it gives back the same answer. `platform`
+ * decides only the shell syntax of the printed command — POSIX `KEY=value
+ * bin` everywhere except win32, where PowerShell needs `$env:KEY = 'value'`
+ * statements instead (see withEnv). The caller reads `process.platform`
+ * once and passes it in, the same way it already does for `port`.
  */
 export function resolveChoice(
   choice: AgentChoice,
-  options: { port: number }
+  options: { port: number; platform: NodeJS.Platform }
 ): Resolution {
   const agent = AGENTS.find((a) => a.id === choice.agent);
 
@@ -1052,7 +1104,7 @@ export function resolveChoice(
   // provider question, or because every setup for this agent is custom
   // (alwaysCustom, e.g. OMP), which never shows that question at all.
   if (agent.alwaysCustom || choice.provider === CUSTOM_ID) {
-    return resolveCustomTarget(agent, choice, options.port);
+    return resolveCustomTarget(agent, choice, options.port, options.platform);
   }
 
   let provider: ProviderEntry | undefined;
@@ -1091,7 +1143,7 @@ export function resolveChoice(
     upstreamHost: provider.upstreamHost,
     renderer: provider.renderer,
     baseUrl,
-    command: buildCommand(provider, baseUrl),
+    command: buildCommand(provider, baseUrl, options.platform),
     setup: (provider.setup ?? []).map((file) => ({
       ...file,
       body: file.body.replace(/\{baseUrl\}/g, baseUrl),

--- a/request-logger/proxy.test.ts
+++ b/request-logger/proxy.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from "vitest";
 import { resolveChoice } from "./agents";
 import { upstreamConnection } from "./proxy";
 
-const PORT = { port: 8787 };
+const PORT = { port: 8787, platform: "linux" as NodeJS.Platform };
 
 /** Resolve, and fail loudly if the answer was not something the proxy can route to. */
 function proxyTarget(...args: Parameters<typeof resolveChoice>) {

--- a/request-logger/proxy.ts
+++ b/request-logger/proxy.ts
@@ -318,7 +318,7 @@ async function main(): Promise<void> {
   let choice = force ? null : loadChoice(STATE_FILE);
   if (!choice) choice = await ask(!force);
 
-  let resolution = resolveChoice(choice, { port: PORT });
+  let resolution = resolveChoice(choice, { port: PORT, platform: process.platform });
 
   // A saved choice the catalogue no longer understands is not the student's
   // fault. Ask again rather than making them find the flag.
@@ -327,7 +327,7 @@ async function main(): Promise<void> {
     console.log(`[request-logger] ${resolution.message}`);
     // A saved file exists, so the student already asked to be remembered.
     choice = await ask(false);
-    resolution = resolveChoice(choice, { port: PORT });
+    resolution = resolveChoice(choice, { port: PORT, platform: process.platform });
   }
 
   if (resolution.kind === "error") {


### PR DESCRIPTION
## Summary

A student on native Windows (PowerShell, not WSL) hit this trying to follow the request-logger lesson:

```
ANTHROPIC_BASE_URL=http://localhost:8787: The term 'ANTHROPIC_BASE_URL=http://localhost:8787' is not
recognized as a name of a cmdlet, function, script file, or executable program.
```

WSL is **not** required for this tool — the actual bug is that `buildCommand` in `request-logger/agents.ts` always printed POSIX shell syntax (`KEY=value bin`), which bash/zsh/WSL/Git Bash understand but native PowerShell does not. PowerShell has no equivalent inline syntax at all; it needs `$env:KEY = 'value'` statements instead.

- `buildCommand` (and the OpenCode custom-target's `OPENCODE_CONFIG_CONTENT` command) now take the platform and print PowerShell syntax on `win32`, leaving POSIX output byte-for-byte unchanged everywhere else.
- `resolveChoice` takes `platform` explicitly alongside `port` (same pattern, same purity guarantee — no reading `process.platform` internally), so `proxy.ts` supplies `process.platform` once and tests can force either branch.
- Added a `powerShellQuote` helper (single-quote literal, doubled-quote escaping) alongside the existing `shellQuote`, used for both the simple `KEY=value` case and the `OPENCODE_CONFIG_CONTENT` JSON-in-env-var case — chosen over double quotes because PowerShell double-quoted strings interpolate `$`, which would be unsafe for JSON config content.
- README: noted the Windows/PowerShell command syntax, added a PowerShell equivalent for the `PORT=9000` override example, and added an honest "not tested end-to-end on real Windows" line next to the existing testing disclaimers.
- 8 new tests covering the win32 branch (Claude Code, Copilot, Pi's no-op case, Codex's unaffected flag-based override, and both OpenCode custom-target command shapes, including single-quote escaping).

Root report also mentioned "no files to backup" in a different, unrelated lesson (`your-starting-context`) — that's course *content*, not this tool, and isn't addressed here.

## Test plan

- [x] `npx vitest run request-logger` — 249/249 passing (241 existing + 8 new)
- [x] `npm run typecheck` — clean
- [ ] A Windows user re-running the printed PowerShell command in an actual PowerShell terminal (not verified end-to-end on real Windows, noted as such in the README)