### PR TITLE
request-logger: fail loudly instead of silently showing an undecoded body as text

### DIFF
--- a/request-logger/render.test.ts
+++ b/request-logger/render.test.ts
@@ -41,10 +41,30 @@ describe("decodeRequestBody", () => {
     expect(decodeRequestBody(compressed, "GZIP")).toBe("hello");
   });
 
-  it("falls back to the raw bytes when the body will not decode", () => {
-    expect(decodeRequestBody(Buffer.from("not compressed"), "zstd")).toBe(
-      "not compressed"
-    );
+  it("fails loudly, instead of silently showing raw bytes as text, when the body will not decode", () => {
+    const out = decodeRequestBody(Buffer.from("not compressed"), "zstd");
+    expect(out).toContain("COULD NOT DECODE");
+    expect(out).toContain("not compressed");
+  });
+
+  it("fails loudly, naming the encoding, for content-encodings it does not know", () => {
+    const out = decodeRequestBody(Buffer.from("hello"), "compress");
+    expect(out).toContain("COULD NOT DECODE");
+    expect(out).toContain("compress");
+  });
+
+  it("fails loudly, naming the Node version, when the runtime has no zstd support", () => {
+    const original = (zlib as any).zstdDecompressSync;
+    delete (zlib as any).zstdDecompressSync;
+    try {
+      const compressed = zlib.zstdCompressSync(Buffer.from("hello"));
+      const out = decodeRequestBody(compressed, "zstd");
+      expect(out).toContain("COULD NOT DECODE");
+      expect(out).toContain("zstd");
+      expect(out).toContain(process.version);
+    } finally {
+      (zlib as any).zstdDecompressSync = original;
+    }
   });
 });
 

--- a/request-logger/render.ts
+++ b/request-logger/render.ts
@@ -44,24 +44,51 @@ const REDACT = new Set([
 /**
  * Turn the raw request bytes into text.
  *
- * Pi compresses its request body with zstd when it talks to the ChatGPT
- * backend. Without this the readable document would be a page of binary. The
- * proxy still forwards, and still saves, the original bytes: only the copy we
- * read is decoded.
+ * Pi and Codex both compress their request body (zstd) when they talk to the
+ * ChatGPT backend. Without this the readable document would be a page of
+ * binary. The proxy still forwards, and still saves, the original bytes:
+ * only the copy we read is decoded.
+ *
+ * A body that claims an encoding but won't decode is never silently shown as
+ * if it were text — that just reproduces the original bug (a page of binary
+ * in the "readable" document) with no clue why. Instead this returns a loud,
+ * unmissable warning ahead of the raw bytes, so a student sees a reason
+ * instead of gibberish.
  */
 export function decodeRequestBody(body: Buffer, encoding?: string): string {
   const kind = (encoding ?? "").trim().toLowerCase();
+  if (kind === "" || kind === "identity") return body.toString("utf8");
+
+  if (kind === "zstd" && typeof (zlib as any).zstdDecompressSync !== "function") {
+    return decodeFailureWarning(
+      body,
+      `this body is zstd-compressed, but this proxy is running on Node ${process.version}, ` +
+        "which has no zlib.zstdDecompressSync (that needs Node >=22.15.0 or >=23.8.0). " +
+        "Upgrade Node and re-send the request to see the real body."
+    );
+  }
+
   try {
-    if (kind === "zstd" && typeof (zlib as any).zstdDecompressSync === "function") {
-      return (zlib as any).zstdDecompressSync(body).toString("utf8");
-    }
+    if (kind === "zstd") return (zlib as any).zstdDecompressSync(body).toString("utf8");
     if (kind === "gzip") return zlib.gunzipSync(body).toString("utf8");
     if (kind === "br") return zlib.brotliDecompressSync(body).toString("utf8");
     if (kind === "deflate") return zlib.inflateSync(body).toString("utf8");
-  } catch {
-    // Fall through: better a raw body than no document at all.
+  } catch (err) {
+    return decodeFailureWarning(
+      body,
+      `this body claims content-encoding "${kind}" but did not decode as that: ${(err as Error).message}`
+    );
   }
-  return body.toString("utf8");
+
+  return decodeFailureWarning(body, `content-encoding "${kind}" is not one this tool decodes`);
+}
+
+function decodeFailureWarning(body: Buffer, reason: string): string {
+  return (
+    `[request-logger] COULD NOT DECODE THIS BODY — ${reason}\n\n` +
+    "The bytes below are still compressed. They are NOT what was actually sent as text:\n\n" +
+    body.toString("utf8")
+  );
 }
 
 export function renderMarkdown(input: RenderInput): string {


### PR DESCRIPTION
## Summary

A student reported (via #ai-coding-crash-course) seeing binary/compressed content in the readable `.md` request-logger output for Codex, right after the WS-timeout fix (#27) let Codex's request actually reach the capture path for the first time.

Root cause: `decodeRequestBody` in `request-logger/render.ts` already handles `Content-Encoding: zstd` (Codex's ChatGPT-subscription route compresses the body, same as Pi), but only when `zlib.zstdDecompressSync` exists — Node ≥22.15.0/≥23.8.0. The README says "Node.js v22+" with nothing enforcing the actual minimum, so a student on an older-but-still-"v22+" Node silently hits the unsupported branch and falls through to `body.toString("utf8")` on the still-compressed bytes — a page of binary rendered as if it were the real request text, no error, no clue why.

More generally, *any* decode failure (corrupt body, wrong encoding, unrecognised `content-encoding` value) was swallowed by a bare `catch` and silently replaced with the raw bytes.

## Change

- `decodeRequestBody` no longer silently falls back to raw bytes on any decode failure. It now returns an unmissable `[request-logger] COULD NOT DECODE THIS BODY — ...` warning ahead of the raw bytes, naming:
  - the content-encoding it tried,
  - why it failed (including, for the zstd/old-Node case specifically, the running Node version and the version needed), and
  - a reminder that the bytes shown are still compressed, not the real text.
- Plain/unencoded and `identity` bodies are unaffected — no warning, same as before.

## Test plan

- [x] `npx vitest run request-logger` — 252/252 passing, including 3 new cases: generic decode failure, unrecognised encoding, and a simulated zstd-unsupported-Node case (temporarily deletes `zlib.zstdDecompressSync` to exercise that branch deterministically).
- [x] `npx tsc --noEmit` — no new errors in `render.ts`/`render.test.ts`.