### PR TITLE
Silence React Router v8 future-flag warnings on dev/build

### DIFF
--- a/react-router.config.ts
+++ b/react-router.config.ts
@@ -4,4 +4,18 @@ export default {
   // Config options...
   // Server-side render by default, to enable SPA mode set this to `false`
   ssr: true,
+
+  // Explicitly opt out of every v8 future flag for now. Leaving these
+  // unset makes react-router print a "Future Flag Warning" for each one on
+  // every `npm run dev` / `npm run build` — accurate, but confusing noise
+  // for anyone new to the repo. Setting them to `false` keeps today's (v7)
+  // behavior and silences the warnings; flip individual flags to `true`
+  // when we're ready to adopt that v8 behavior ahead of the real upgrade.
+  future: {
+    v8_middleware: false,
+    v8_splitRouteModules: false,
+    v8_viteEnvironmentApi: false,
+    v8_passThroughRequests: false,
+    v8_trailingSlashAwareDataRequests: false,
+  },
 } satisfies Config;


### PR DESCRIPTION
## Summary
- `npm run dev` (and `npm run build`) currently print five "Future Flag Warning" lines every time, because react-router 7.18.2 warns whenever a `future.v8_*` flag is left unset ahead of the v8 release.
- These are harmless but confusing for students who are new to the repo and don't know what a "future flag" is.
- `react-router.config.ts` now explicitly sets all five `v8_*` flags to `false`, which keeps today's v7 behavior byte-for-byte and just silences the console noise. Flags can be flipped to `true` individually later when we're ready to adopt that v8 behavior ahead of an eventual real upgrade.

## Test plan
- [x] `npm run dev` — confirmed no "Future Flag Warning" lines in the output
- [x] `npm run typecheck` — passes
- [x] `npm run build` — passes (pre-existing unrelated warnings about unused drizzle-orm imports and sourcemaps, present before this change too)

Note: this repo also has a `live-run-through` branch (main + a stack of lesson commits) that will need this same commit rebased in once this merges, per the course-repo "Edit main" workflow. Happy to do that as a follow-up once this is merged.