### PR TITLE
request-logger: add Claude Code + Google Vertex AI provider

### DIFF
--- a/request-logger/README.md
+++ b/request-logger/README.md
@@ -106,7 +106,7 @@ from this table. It is here so you can see what is supported before you start.
 
 | Agent          | Works | What you need                                 |
 | -------------- | ----- | --------------------------------------------- |
-| Claude Code    | Yes   | One command. Works with a subscription login. |
+| Claude Code    | Yes   | One command. Works with a subscription login, an Anthropic API key, or Google Vertex AI. |
 | Codex          | Yes   | One flag. A subscription or an API key works. |
 | GitHub Copilot | Yes   | Your normal subscription login.               |
 | OpenCode       | Yes   | One command, or a config file.                |
@@ -119,6 +119,21 @@ from this table. It is here so you can see what is supported before you start.
 Any other provider — a local model server, or a smaller hosted one — works
 through **Custom base URL**, above, on any agent in this table except Cursor
 and Amp.
+
+### Claude Code on Google Vertex AI
+
+If your Claude Code already talks to Vertex AI (`CLAUDE_CODE_USE_VERTEX=1` is
+set), pick **Google Vertex AI** at the provider question instead of
+**Anthropic**. Vertex mode reads a different variable for a base-URL
+override — `ANTHROPIC_VERTEX_BASE_URL`, not `ANTHROPIC_BASE_URL` — because
+`ANTHROPIC_BASE_URL` belongs to the direct-API code path and is silently
+ignored once Vertex mode is on. Picking **Anthropic** here while
+`CLAUDE_CODE_USE_VERTEX=1` is set is the most common way a Vertex student's
+logs folder stays empty with no error at all.
+
+This route only covers `CLOUD_ML_REGION=global`, the default and most common
+setting. A regional value (`us-east5`, say) talks to a different host and
+is not wired up yet — ask for it via the issue tracker if you hit this.
 
 ### Why Cursor and Amp cannot work
 
@@ -273,11 +288,14 @@ of these happened:
 
 Be fair to the tool when you judge a failure.
 
-- **Claude Code and OMP are tested end to end.** The measurements above are
-  real, and OMP is run daily by the person who built this tool.
+- **Claude Code on the direct Anthropic API, and OMP, are tested end to end.**
+  The measurements above are real, and OMP is run daily by the person who
+  built this tool.
 - **The others were verified** by reading the published code of each agent and
   by driving them against a local listener. They were not each run through a
-  full course of the lesson.
+  full course of the lesson. Claude Code on Google Vertex AI is in this
+  group — verified against Anthropic's own Vertex documentation, not yet
+  driven against a real Vertex project.
 - **A custom base URL is only as tested as the agent it is attached to.** The
   base URL and wire format mechanism itself is tested directly (see
   `agents.test.ts`); a specific third-party server behind it has not

--- a/request-logger/agents.test.ts
+++ b/request-logger/agents.test.ts
@@ -105,9 +105,9 @@ describe("listAgents", () => {
     expect(claude?.supported).toBe(true);
   });
 
-  it("says Claude Code needs no provider question", () => {
+  it("says Claude Code needs a provider question now it has Vertex AI too", () => {
     const claude = listAgents().find((agent) => agent.id === "claude-code");
-    expect(claude?.needsProvider).toBe(false);
+    expect(claude?.needsProvider).toBe(true);
   });
 
   it("says OpenCode needs a provider question", () => {
@@ -138,11 +138,22 @@ describe("listAgents", () => {
 
 describe("listProviders", () => {
   it("returns nothing for an agent with one provider", () => {
-    expect(listProviders("claude-code")).toEqual([]);
+    expect(listProviders("copilot")).toEqual([]);
   });
 
   it("returns nothing for a refused agent", () => {
     expect(listProviders("cursor")).toEqual([]);
+  });
+
+  it("returns both Claude Code providers", () => {
+    expect(listProviders("claude-code").map((p) => p.id)).toEqual([
+      "anthropic",
+      "vertex",
+    ]);
+  });
+
+  it("leads Claude Code with the Anthropic route, which is the simplest", () => {
+    expect(listProviders("claude-code")[0].id).toBe("anthropic");
   });
 
   it("returns both OpenCode providers", () => {
@@ -167,13 +178,7 @@ describe("listProviders", () => {
 
 describe("agentProviders", () => {
   it("returns the one provider a single-provider agent has, unlike listProviders", () => {
-    expect(listProviders("claude-code")).toEqual([]);
-    expect(agentProviders("claude-code").map((p) => p.id)).toEqual([
-      "anthropic",
-    ]);
-  });
-
-  it("returns the one provider Copilot has too", () => {
+    expect(listProviders("copilot")).toEqual([]);
     expect(agentProviders("copilot").map((p) => p.id)).toEqual(["github"]);
   });
 
@@ -197,7 +202,21 @@ describe("agentProviders", () => {
 
 describe("resolveChoice — upstream hosts", () => {
   it("sends Claude Code to Anthropic", () => {
-    expect(target("claude-code").upstreamHost).toBe("api.anthropic.com");
+    expect(target("claude-code", "anthropic").upstreamHost).toBe(
+      "api.anthropic.com"
+    );
+  });
+
+  it("sends Claude Code on Vertex AI to the global Vertex endpoint", () => {
+    expect(target("claude-code", "vertex").upstreamHost).toBe(
+      "aiplatform.googleapis.com"
+    );
+  });
+
+  it("gives Claude Code's two providers different hosts", () => {
+    expect(target("claude-code", "anthropic").upstreamHost).not.toBe(
+      target("claude-code", "vertex").upstreamHost
+    );
   });
 
   it("sends Codex on an API key to OpenAI", () => {
@@ -259,7 +278,11 @@ describe("resolveChoice — upstream hosts", () => {
 
 describe("resolveChoice — renderers", () => {
   it("reads Claude Code with the Anthropic renderer", () => {
-    expect(target("claude-code").renderer).toBe("anthropic");
+    expect(target("claude-code", "anthropic").renderer).toBe("anthropic");
+  });
+
+  it("reads Claude Code on Vertex AI with the Anthropic renderer too, since Vertex's Claude endpoint is the same Messages API shape", () => {
+    expect(target("claude-code", "vertex").renderer).toBe("anthropic");
   });
 
   it("reads Codex with the OpenAI renderer", () => {
@@ -297,7 +320,15 @@ describe("resolveChoice — base URLs", () => {
   });
 
   it("gives Claude Code no suffix, because it appends the whole path itself", () => {
-    expect(target("claude-code").baseUrl).toBe("http://localhost:8787");
+    expect(target("claude-code", "anthropic").baseUrl).toBe(
+      "http://localhost:8787"
+    );
+  });
+
+  it("gives Claude Code on Vertex AI no suffix either, for the same reason", () => {
+    expect(target("claude-code", "vertex").baseUrl).toBe(
+      "http://localhost:8787"
+    );
   });
 
   it("gives Copilot no suffix", () => {
@@ -321,14 +352,20 @@ describe("resolveChoice — base URLs", () => {
   });
 
   it("uses the port it is given", () => {
-    const result = resolveChoice({ agent: "claude-code" }, { port: 9000, platform: "linux" });
+    const result = resolveChoice(
+      { agent: "claude-code", provider: "anthropic" },
+      { port: 9000, platform: "linux" }
+    );
     expect(result.kind === "target" && result.baseUrl).toBe(
       "http://localhost:9000"
     );
   });
 
   it("puts the chosen port into the command", () => {
-    const result = resolveChoice({ agent: "claude-code" }, { port: 9000, platform: "linux" });
+    const result = resolveChoice(
+      { agent: "claude-code", provider: "anthropic" },
+      { port: 9000, platform: "linux" }
+    );
     expect(result.kind === "target" && result.command).toContain(
       "http://localhost:9000"
     );
@@ -337,18 +374,35 @@ describe("resolveChoice — base URLs", () => {
 
 describe("resolveChoice — commands", () => {
   it("turns tool search back on for Claude Code", () => {
-    expect(target("claude-code").command).toContain("ENABLE_TOOL_SEARCH=true");
+    expect(target("claude-code", "anthropic").command).toContain(
+      "ENABLE_TOOL_SEARCH=true"
+    );
   });
 
   it("uses the plain variable name, not the prefixed one", () => {
-    expect(target("claude-code").command).not.toContain(
+    expect(target("claude-code", "anthropic").command).not.toContain(
       "CLAUDE_CODE_ENABLE_TOOL_SEARCH"
     );
   });
 
   it("sets the base URL for Claude Code", () => {
-    expect(target("claude-code").command).toBe(
+    expect(target("claude-code", "anthropic").command).toBe(
       "ANTHROPIC_BASE_URL=http://localhost:8787 ENABLE_TOOL_SEARCH=true claude"
+    );
+  });
+
+  it("sets the Vertex base URL variable for Claude Code on Vertex AI, not the plain Anthropic one", () => {
+    // ANTHROPIC_BASE_URL is silently ignored once Claude Code is in Vertex
+    // mode (CLAUDE_CODE_USE_VERTEX=1) — this is the whole reason the two
+    // providers need different env vars.
+    expect(target("claude-code", "vertex").command).toBe(
+      "ANTHROPIC_VERTEX_BASE_URL=http://localhost:8787 ENABLE_TOOL_SEARCH=true claude"
+    );
+  });
+
+  it("never puts the plain Anthropic variable in the Vertex command", () => {
+    expect(target("claude-code", "vertex").command).not.toContain(
+      "ANTHROPIC_BASE_URL=http://localhost:8787 "
     );
   });
 
@@ -433,15 +487,22 @@ describe("resolveChoice — commands on win32", () => {
   }
 
   it("uses PowerShell $env: syntax instead of POSIX VAR=value", () => {
-    expect(winTarget("claude-code").command).toBe(
+    expect(winTarget("claude-code", "anthropic").command).toBe(
       "$env:ANTHROPIC_BASE_URL = 'http://localhost:8787'; " +
         "$env:ENABLE_TOOL_SEARCH = 'true'; claude"
     );
   });
 
   it("never prints the POSIX VAR=value form on win32", () => {
-    expect(winTarget("claude-code").command).not.toMatch(
+    expect(winTarget("claude-code", "anthropic").command).not.toMatch(
       /^ANTHROPIC_BASE_URL=/
+    );
+  });
+
+  it("uses PowerShell $env: syntax for Claude Code on Vertex AI too", () => {
+    expect(winTarget("claude-code", "vertex").command).toBe(
+      "$env:ANTHROPIC_VERTEX_BASE_URL = 'http://localhost:8787'; " +
+        "$env:ENABLE_TOOL_SEARCH = 'true'; claude"
     );
   });
 
@@ -486,7 +547,11 @@ describe("resolveChoice — setup files", () => {
   });
 
   it("gives Claude Code no config file to write", () => {
-    expect(target("claude-code").setup).toEqual([]);
+    expect(target("claude-code", "anthropic").setup).toEqual([]);
+  });
+
+  it("gives Claude Code on Vertex AI no config file either — it's all env vars", () => {
+    expect(target("claude-code", "vertex").setup).toEqual([]);
   });
 
   it("gives Pi its models file, because Pi has no variable to set", () => {
@@ -529,8 +594,21 @@ describe("resolveChoice — setup files", () => {
 
 describe("resolveChoice — notes and warnings", () => {
   it("explains the tool search flag to a Claude Code student", () => {
-    expect(target("claude-code").notes.join(" ")).toContain(
+    expect(target("claude-code", "anthropic").notes.join(" ")).toContain(
       "ENABLE_TOOL_SEARCH"
+    );
+  });
+
+  it("tells a Vertex AI student that ANTHROPIC_BASE_URL is ignored in Vertex mode", () => {
+    const notes = target("claude-code", "vertex").notes.join(" ");
+    expect(notes).toContain("ANTHROPIC_VERTEX_BASE_URL");
+    expect(notes).toContain("ANTHROPIC_BASE_URL");
+    expect(notes).toContain("silently ignored");
+  });
+
+  it("tells a Vertex AI student this entry only covers the global region", () => {
+    expect(target("claude-code", "vertex").notes.join(" ")).toContain(
+      "CLOUD_ML_REGION=global"
     );
   });
 
@@ -605,6 +683,26 @@ describe("shouldLogRequest", () => {
   it("drops Anthropic token counting", () => {
     expect(
       shouldLogRequest("POST", "/v1/messages/count_tokens", "anthropic")
+    ).toBe(false);
+  });
+
+  it("logs a real Claude Code on Vertex AI turn", () => {
+    expect(
+      shouldLogRequest(
+        "POST",
+        "/v1/projects/my-proj/locations/global/publishers/anthropic/models/claude-sonnet-4-5:streamRawPredict",
+        "anthropic"
+      )
+    ).toBe(true);
+  });
+
+  it("drops Vertex AI token counting, which uses countTokens instead of count_tokens", () => {
+    expect(
+      shouldLogRequest(
+        "POST",
+        "/v1/projects/my-proj/locations/global/publishers/anthropic/models/claude-sonnet-4-5:countTokens",
+        "anthropic"
+      )
     ).toBe(false);
   });
 
@@ -696,13 +794,21 @@ describe("resolveChoice — bad input", () => {
   });
 
   it("accepts a single-provider agent with no provider given", () => {
-    expect(resolveChoice({ agent: "claude-code" }, PORT).kind).toBe("target");
+    // Claude Code no longer qualifies now it has two providers (see below) —
+    // Copilot is still single-provider and exercises this general case.
+    expect(resolveChoice({ agent: "copilot" }, PORT).kind).toBe("target");
   });
 
   it("ignores a stale provider on a single-provider agent", () => {
-    expect(target("claude-code", "whatever").upstreamHost).toBe(
-      "api.anthropic.com"
+    expect(target("copilot", "whatever").upstreamHost).toBe(
+      "api.githubcopilot.com"
     );
+  });
+
+  it("now requires a provider for Claude Code, since it has two", () => {
+    const result = resolveChoice({ agent: "claude-code" }, PORT);
+    expect(result.kind).toBe("error");
+    expect(result.kind === "error" && result.message).toContain("vertex");
   });
 
   it("points the student at --force when a choice cannot be resolved", () => {
@@ -1162,7 +1268,13 @@ describe("resolveChoice — custom base URL, per-agent command template", () => 
     expect(result.notes.join(" ")).not.toContain("whole built-in model list");
   });
 
-  it("reuses Claude Code's own template regardless of the wire format chosen, since it has only one", () => {
+  it("reuses Claude Code's Anthropic template regardless of the wire format chosen, since that provider is tagged as the catch-all", () => {
+    // Claude Code now has two providers (anthropic, vertex), so this no
+    // longer falls out of findCustomTemplate's single-provider shortcut —
+    // it works because the "anthropic" provider is tagged
+    // customTemplateFor: ["anthropic", "openai", "raw"]. "vertex" is
+    // untagged on purpose: it needs Google Cloud auth, so it would silently
+    // misconfigure an unrelated custom server.
     const result = customTarget({
       agent: "claude-code",
       provider: CUSTOM_ID,

--- a/request-logger/agents.ts
+++ b/request-logger/agents.ts
@@ -310,6 +310,15 @@ const AGENTS: AgentEntry[] = [
           ["ENABLE_TOOL_SEARCH", "true"],
         ],
         bin: "claude",
+        // Claude Code's own wire format is Anthropic-shaped regardless of
+        // what a custom target claims to speak, so this stays the catch-all
+        // for every wire format a custom target might pick — the same
+        // "used regardless of the wire format chosen" guarantee this agent
+        // had when it was the only provider, back when findCustomTemplate's
+        // single-provider branch picked it unconditionally. Now that
+        // "vertex" (below) is a second provider, that branch no longer
+        // fires, so the guarantee has to be spelled out here instead.
+        customTemplateFor: ["anthropic", "openai", "raw"],
         notes: [
           "ENABLE_TOOL_SEARCH=true is important. Claude Code trusts one host only. " +
             "When the base URL points somewhere else, it turns off tool search, stops " +
@@ -318,6 +327,44 @@ const AGENTS: AgentEntry[] = [
             "flag turns that effect off, so what you read is what Claude Code really sends.",
           "This works with a Claude subscription login. Your login stays active. " +
             "Only the model traffic moves.",
+        ],
+      },
+      {
+        id: "vertex",
+        label: "Google Vertex AI",
+        // Fixed to the global endpoint on purpose — see the region note below.
+        upstreamHost: "aiplatform.googleapis.com",
+        // Vertex's Claude endpoint is Anthropic's own Messages API shape,
+        // routed by URL path instead of a body field — the model ID moves
+        // from the body's "model" key into the URL
+        // (.../publishers/anthropic/models/{model}:streamRawPredict), and
+        // the body gains "anthropic_version". findModel() in render.ts
+        // already falls back to reading the model out of the path when the
+        // body has none, and the Anthropic renderer only reads specific
+        // known keys, so the existing "anthropic" renderer reads this
+        // correctly without a dedicated renderer of its own.
+        renderer: "anthropic",
+        env: [
+          ["ANTHROPIC_VERTEX_BASE_URL", "{baseUrl}"],
+          ["ENABLE_TOOL_SEARCH", "true"],
+        ],
+        bin: "claude",
+        notes: [
+          "This assumes CLAUDE_CODE_USE_VERTEX=1, CLOUD_ML_REGION and " +
+            "ANTHROPIC_VERTEX_PROJECT_ID are already exported in your shell — " +
+            "request-logger does not set those, only ANTHROPIC_VERTEX_BASE_URL, " +
+            "which is the variable Claude Code actually reads for a base-URL " +
+            "override once Vertex mode is on. ANTHROPIC_BASE_URL, used by the " +
+            "plain Anthropic route above, is silently ignored in Vertex mode — " +
+            "that mismatch is the usual reason a Vertex student's logs folder " +
+            "stays empty.",
+          "Only CLOUD_ML_REGION=global is supported by this entry. A regional " +
+            "value (us-east5, say) talks to a different host " +
+            "({region}-aiplatform.googleapis.com), which this entry does not " +
+            "resolve to yet — ask for it via the issue tracker if you hit this.",
+          "ENABLE_TOOL_SEARCH=true matters here for the same reason it does on " +
+            "the plain Anthropic route above: a non-default host turns off tool " +
+            "search unless this is set.",
         ],
       },
     ],
@@ -702,7 +749,11 @@ export function agentProviders(agentId: string): ProviderSummary[] {
  *
  *  - A model call is always a POST. Agents also send connectivity probes, which
  *    would otherwise write an empty document at the top of the logs folder.
- *  - Anthropic counts tokens with a `count_tokens` path.
+ *  - The direct Anthropic API counts tokens with a `count_tokens` path.
+ *    Claude Code on Vertex AI reaches the same Anthropic wire format through a
+ *    Vertex-style URL instead, whose token-counting call ends
+ *    `:countTokens` — Vertex's own camelCase, colon-suffixed convention,
+ *    not Anthropic's underscored one — so both spellings are matched below.
  *  - Gemini counts tokens under a different name, and on the Google login route
  *    it fires several calls that carry no prompt at all. On that route the only
  *    calls worth keeping are the ones that generate content.
@@ -716,7 +767,9 @@ export function shouldLogRequest(
   // Case-insensitive on purpose: the streaming call is `:streamGenerateContent`,
   // with a capital G, and the non-streaming one is `:generateContent`.
   if (renderer === "gemini") return /generateContent/i.test(reqPath);
-  return !reqPath.includes("count_tokens");
+  // Matches both `count_tokens` (direct Anthropic API) and `countTokens`
+  // (Claude Code on Vertex AI).
+  return !/count[_-]?tokens/i.test(reqPath);
 }
 
 // ---------------------------------------------------------------------------

--- a/request-logger/proxy.test.ts
+++ b/request-logger/proxy.test.ts
@@ -25,7 +25,10 @@ function proxyTarget(...args: Parameters<typeof resolveChoice>) {
 
 describe("upstreamConnection", () => {
   it("keeps a catalogue target on https and port 443, unchanged", () => {
-    const target = proxyTarget({ agent: "claude-code" }, PORT);
+    const target = proxyTarget(
+      { agent: "claude-code", provider: "anthropic" },
+      PORT
+    );
     expect(upstreamConnection(target)).toEqual({
       hostname: "api.anthropic.com",
       port: 443,


### PR DESCRIPTION
## Summary

- Adds a second Claude Code provider — **Google Vertex AI** — to `request-logger`'s catalogue. Claude Code silently ignores `ANTHROPIC_BASE_URL` once `CLAUDE_CODE_USE_VERTEX=1` is set; it reads `ANTHROPIC_VERTEX_BASE_URL` instead (per [Anthropic's Vertex docs](https://code.claude.com/docs/en/google-vertex-ai)). That mismatch is why a Vertex student's `request-logger/logs/` folder stayed empty with no error.
- Fixes `shouldLogRequest`'s token-counting filter to also match Vertex's camelCase `:countTokens` path segment, not just the direct API's `count_tokens`.
- Tags the existing "Anthropic" provider as the Custom-base-url catch-all (`customTemplateFor`), since Claude Code having a second provider means `findCustomTemplate`'s old "only one provider, use it unconditionally" shortcut no longer fires.
- Updates the README with a short "Claude Code on Google Vertex AI" section and marks the route as doc-verified, not yet driven against a real Vertex project (matching the README's own "how much this was tested" honesty convention).

No changes needed in `config.ts`, `proxy.ts`, or `render.ts` — the wizard's provider question, the proxy's routing, and the Anthropic renderer are all already generic over the catalogue (`render.ts`'s `findModel()` already falls back to reading the model out of the URL path, which is exactly Vertex's shape).

Only `CLOUD_ML_REGION=global` is supported by this entry — a regional value talks to a different host and isn't wired up yet.

Reported in ai-coding-crash-course#33.

## Test plan

- [x] `npx vitest run request-logger/` — 271 passed, including new cases for the Vertex provider (upstream host, renderer, base URL, command, win32 PowerShell syntax, notes, and `shouldLogRequest`) and updated cases where Claude Code gaining a second provider changed existing behavior (provider question now asked, single-provider shortcuts moved to Copilot as the example).
- [x] `npm run typecheck` — clean.
- [ ] Not yet driven against a real Vertex AI project — asked the original reporter to confirm the `ANTHROPIC_VERTEX_BASE_URL` command actually produces a capture.
