### PR TITLE
request-logger: add Junie support

### DIFF
--- a/request-logger/README.md
+++ b/request-logger/README.md
@@ -113,6 +113,7 @@ from this table. It is here so you can see what is supported before you start.
 | Pi             | Yes   | A config file. Pi has no base URL variable.   |
 | OMP            | Yes   | A YAML config file. Point it at any backend.  |
 | Gemini CLI     | Yes   | One command. The free Google login works.     |
+| Junie          | Yes   | A config file, and a real API key pasted in — see below. |
 | Cursor CLI     | No    | Nothing can make it work. See below.          |
 | Amp            | No    | Nothing can make it work. See below.          |
 
@@ -134,6 +135,24 @@ logs folder stays empty with no error at all.
 This route only covers `CLOUD_ML_REGION=global`, the default and most common
 setting. A regional value (`us-east5`, say) talks to a different host and
 is not wired up yet — ask for it via the issue tracker if you hit this.
+
+### Junie
+
+Junie is BYOK across several backends, with no fixed host of its own — the
+same shape as OMP — so it goes through the base URL and wire format
+questions like a custom target does, picking a real Anthropic-compatible or
+OpenAI-compatible template depending which you choose. It writes a proxy
+entry to `~/.junie/config.json` (user scope; a project-scope file at
+`<project-root>/.junie/config.json` takes precedence if you have one — see
+Junie's own docs), merged in alongside whatever else is already there.
+
+Junie is the one agent here with no existing login for this tool to pass
+through. Its custom-proxy mechanism bypasses JetBrains AI authentication
+entirely, so the printed config carries a placeholder header line and you
+paste in a real API key yourself — an Anthropic key on the
+Anthropic-compatible route, an OpenAI key on the OpenAI-compatible one.
+Treat that file the way you would any other file holding a real key: do not
+commit it.
 
 ### Why Cursor and Amp cannot work
 
@@ -296,6 +315,13 @@ Be fair to the tool when you judge a failure.
   full course of the lesson. Claude Code on Google Vertex AI is in this
   group — verified against Anthropic's own Vertex documentation, not yet
   driven against a real Vertex project.
+- **Junie is the least-verified entry in the catalogue.** Junie CLI is
+  closed source, so unlike every other agent here its entry was not checked
+  against real source, only against JetBrains' published Junie CLI docs
+  (`config.json`, custom proxies, and CLI reference). It has not been driven
+  against a real Junie install. If the proxy `kind`, the config file's
+  precise shape, or the header format is wrong, that is the likely reason,
+  and the fix is one line in `agents.ts`.
 - **A custom base URL is only as tested as the agent it is attached to.** The
   base URL and wire format mechanism itself is tested directly (see
   `agents.test.ts`); a specific third-party server behind it has not

--- a/request-logger/agents.test.ts
+++ b/request-logger/agents.test.ts
@@ -83,6 +83,7 @@ describe("listAgents", () => {
       "pi",
       "omp",
       "gemini",
+      "junie",
       "cursor",
       "amp",
     ]);
@@ -126,13 +127,30 @@ describe("listAgents", () => {
   });
 
   it("says no other agent is always custom", () => {
-    const others = listAgents().filter((agent) => agent.id !== "omp");
+    const others = listAgents().filter(
+      (agent) => agent.id !== "omp" && agent.id !== "junie"
+    );
     expect(others.every((agent) => agent.alwaysCustom === false)).toBe(true);
   });
 
   it("says OMP needs no provider question, because it never shows one", () => {
     const omp = listAgents().find((agent) => agent.id === "omp");
     expect(omp?.needsProvider).toBe(false);
+  });
+
+  it("marks Junie as supported and always custom", () => {
+    const junie = listAgents().find((agent) => agent.id === "junie");
+    expect(junie?.supported).toBe(true);
+    expect(junie?.alwaysCustom).toBe(true);
+  });
+
+  it("says Junie needs no provider question either, even though it has two internal templates", () => {
+    // Junie is the first alwaysCustom agent with more than one catalogue
+    // provider (see findCustomTemplate) — needsProvider must stay false
+    // regardless, because askChoice skips the provider question for any
+    // alwaysCustom agent before providers.length is ever consulted.
+    const junie = listAgents().find((agent) => agent.id === "junie");
+    expect(junie?.needsProvider).toBe(false);
   });
 });
 
@@ -197,6 +215,15 @@ describe("agentProviders", () => {
     expect(agentProviders("opencode").map((p) => p.id)).toEqual(
       listProviders("opencode").map((p) => p.id)
     );
+  });
+
+  it("returns Junie's two internal template providers, even though the wizard never shows them", () => {
+    // Same reasoning as OMP above, except Junie has two templates to pick
+    // between (see findCustomTemplate) rather than one.
+    expect(agentProviders("junie").map((p) => p.id)).toEqual([
+      "anthropic",
+      "openai",
+    ]);
   });
 });
 
@@ -1396,5 +1423,115 @@ describe("resolveChoice — OMP", () => {
 
   it("rejects OMP with no base URL", () => {
     expect(resolveChoice({ agent: "omp" }, PORT).kind).toBe("error");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Junie — every setup is custom, and (unlike OMP) has two templates to pick
+// between by wire format
+// ---------------------------------------------------------------------------
+
+describe("resolveChoice — Junie", () => {
+  it("resolves Junie straight from a base URL and wire format, with no provider needed", () => {
+    const result = resolveChoice(
+      {
+        agent: "junie",
+        customBaseUrl: "http://localhost:8787",
+        customRenderer: "anthropic",
+      },
+      PORT
+    );
+    expect(result.kind).toBe("custom-target");
+  });
+
+  it("gives Junie its own bin, with no env vars", () => {
+    const result = customTarget({
+      agent: "junie",
+      customBaseUrl: "http://localhost:11434",
+      customRenderer: "anthropic",
+    });
+    expect(result.command).toBe("junie");
+  });
+
+  it("writes an Anthropic-kind proxy entry for the anthropic-compatible route", () => {
+    const result = customTarget({
+      agent: "junie",
+      customBaseUrl: "http://localhost:11434",
+      customRenderer: "anthropic",
+    });
+    expect(result.setup).toHaveLength(1);
+    expect(result.setup[0].path).toBe("~/.junie/config.json");
+    expect(result.setup[0].language).toBe("json");
+    expect(result.setup[0].body).toContain('"kind": "Anthropic"');
+    expect(result.setup[0].body).toContain(
+      '"api-url": "http://localhost:8787"'
+    );
+    expect(result.setup[0].body).toContain("x-api-key:");
+    expect(result.setup[0].body).toContain('"provider": "request-logger"');
+  });
+
+  it("writes an OpenAI-kind proxy entry for the openai-compatible route", () => {
+    const result = customTarget({
+      agent: "junie",
+      customBaseUrl: "http://localhost:11434",
+      customRenderer: "openai",
+    });
+    expect(result.setup[0].body).toContain('"kind": "OpenAI"');
+    expect(result.setup[0].body).toContain("Authorization: Bearer");
+  });
+
+  it("defaults Junie's raw/not-sure custom target to the OpenAI-kind template", () => {
+    // Same convention as OpenCode and Pi's custom targets: an unidentified
+    // custom server is far more often OpenAI-compatible than
+    // Anthropic-compatible.
+    const result = customTarget({
+      agent: "junie",
+      customBaseUrl: "http://localhost:11434",
+      customRenderer: "raw",
+    });
+    expect(result.setup[0].body).toContain('"kind": "OpenAI"');
+  });
+
+  it("never sends Junie's Anthropic-kind api-key header on the OpenAI route, or vice versa", () => {
+    const anthropicRoute = customTarget({
+      agent: "junie",
+      customBaseUrl: "http://localhost:11434",
+      customRenderer: "anthropic",
+    });
+    const openaiRoute = customTarget({
+      agent: "junie",
+      customBaseUrl: "http://localhost:11434",
+      customRenderer: "openai",
+    });
+    expect(anthropicRoute.setup[0].body).not.toContain("Authorization: Bearer");
+    expect(openaiRoute.setup[0].body).not.toContain("x-api-key:");
+  });
+
+  it("warns that Junie's proxy bypasses JetBrains AI authentication, unlike every login-based agent here", () => {
+    const result = customTarget({
+      agent: "junie",
+      customBaseUrl: "http://localhost:11434",
+      customRenderer: "anthropic",
+    });
+    expect(result.notes.some((note) => note.includes("bypasses"))).toBe(true);
+  });
+
+  it("still resolves Junie even when the saved provider field is stale", () => {
+    // alwaysCustom agents ignore whatever is saved under `provider`; only
+    // the custom base URL and renderer matter.
+    const result = resolveChoice(
+      {
+        agent: "junie",
+        provider: "whatever-was-saved-before",
+        customBaseUrl: "http://localhost:11434",
+        customRenderer: "raw",
+      },
+      PORT
+    );
+    expect(result.kind).toBe("custom-target");
+  });
+
+  it("rejects Junie with no base URL", () => {
+    expect(resolveChoice({ agent: "junie" }, PORT).kind).toBe("error");
   });
 });

--- a/request-logger/agents.ts
+++ b/request-logger/agents.ts
@@ -335,11 +335,6 @@ const JUNIE_MERGE_NOTE =
   "the proxies entry and the provider key alongside whatever else is " +
   "already in that file.";
 
-// Junie's testing status (verified against JetBrains' published docs, not
-// yet driven against a real install) is recorded in the README's "How much
-// this was tested" section, the same way every other agent's is — it is not
-// printed to the student, the same way no other agent's is either.
-
 const OPENCODE_NOTE =
   "The environment variable above works, but only by accident: OpenCode passes " +
   "no base URL of its own for this provider, so the bundled SDK falls back to " +
@@ -718,6 +713,13 @@ const AGENTS: AgentEntry[] = [
     // OpenRouter, Copilot, a LiteLLM proxy) with no single fixed host of its
     // own — the same shape as OMP — so every setup for it is custom too. See
     // AgentEntry.alwaysCustom.
+    //
+    // Junie CLI is closed source, so unlike every other entry in this
+    // catalogue this one is verified against JetBrains' published docs only,
+    // not against real source or a real install. Testing status is recorded
+    // in the README's "How much this was tested" section, the same way every
+    // other agent's is; it is not printed to the student, the same way no
+    // other agent's is either.
     alwaysCustom: true,
     providers: [
       {
@@ -741,6 +743,9 @@ const AGENTS: AgentEntry[] = [
       {
         id: "openai",
         label: "OpenAI-compatible",
+        // Unused, same as the Anthropic-compatible entry above: Junie never
+        // reaches the normal (non-custom) resolution path that would read
+        // this. See resolveCustomTarget.
         upstreamHost: "",
         renderer: "raw",
         bin: "junie",

--- a/request-logger/agents.ts
+++ b/request-logger/agents.ts
@@ -286,6 +286,60 @@ const OMP_NOTE =
   "any other server that speaks one of the wire formats offered here, so " +
   "every OMP setup goes through the base URL and wire format you chose.";
 
+/**
+ * Junie's custom-proxy override, in JSON, under ~/.junie/config.json (user
+ * scope; see Junie's own configuration-files docs for how a project-scope
+ * file layers on top). Unlike ompModels/piModels, this one genuinely differs
+ * by wire format: Junie's proxy entry declares a `kind` — the protocol Junie
+ * itself will speak on the wire — so a mismatched kind does not 404, it just
+ * sends the wrong shape of request. That is why Junie gets two catalogue
+ * providers below (tagged by customTemplateFor) instead of OMP's one: the
+ * kind, and the auth header format that goes with it, must track the
+ * renderer the student actually picked.
+ *
+ * `authHeader` is a placeholder line, not a real credential — see JUNIE_NOTE.
+ */
+function junieConfig(
+  baseUrl: string,
+  kind: "Anthropic" | "OpenAI",
+  authHeader: string
+): SetupFile {
+  return {
+    path: "~/.junie/config.json",
+    language: "json",
+    body: [
+      "{",
+      '  "proxies": [',
+      "    {",
+      '      "name": "request-logger",',
+      `      "kind": "${kind}",`,
+      `      "api-url": "${baseUrl}",`,
+      `      "headers": ["${authHeader}"]`,
+      "    }",
+      "  ],",
+      '  "provider": "request-logger"',
+      "}",
+    ].join("\n"),
+  };
+}
+
+const JUNIE_NOTE =
+  "Junie has no existing login for this tool to pass through the way Claude " +
+  "Code or Codex do. Its custom proxy bypasses JetBrains AI authentication " +
+  "entirely, so a real API key for whichever backend you are logging goes " +
+  "straight into config.json's headers array in plaintext. Do not commit " +
+  "this file.";
+
+const JUNIE_MERGE_NOTE =
+  "This is merged into ~/.junie/config.json, not a replacement for it — add " +
+  "the proxies entry and the provider key alongside whatever else is " +
+  "already in that file.";
+
+// Junie's testing status (verified against JetBrains' published docs, not
+// yet driven against a real install) is recorded in the README's "How much
+// this was tested" section, the same way every other agent's is — it is not
+// printed to the student, the same way no other agent's is either.
+
 const OPENCODE_NOTE =
   "The environment variable above works, but only by accident: OpenCode passes " +
   "no base URL of its own for this provider, so the bundled SDK falls back to " +
@@ -658,6 +712,54 @@ const AGENTS: AgentEntry[] = [
     ],
   },
   {
+    id: "junie",
+    label: "Junie",
+    // Junie is BYOK across several backends (OpenAI, Anthropic, Google, xAI,
+    // OpenRouter, Copilot, a LiteLLM proxy) with no single fixed host of its
+    // own — the same shape as OMP — so every setup for it is custom too. See
+    // AgentEntry.alwaysCustom.
+    alwaysCustom: true,
+    providers: [
+      {
+        id: "anthropic",
+        label: "Anthropic-compatible",
+        // Unused: Junie never reaches the normal (non-custom) resolution
+        // path that would read this. See resolveCustomTarget.
+        upstreamHost: "",
+        renderer: "raw",
+        bin: "junie",
+        customTemplateFor: ["anthropic"],
+        setup: [
+          junieConfig(
+            "{baseUrl}",
+            "Anthropic",
+            "x-api-key: YOUR_ANTHROPIC_API_KEY"
+          ),
+        ],
+        notes: [JUNIE_NOTE, JUNIE_MERGE_NOTE],
+      },
+      {
+        id: "openai",
+        label: "OpenAI-compatible",
+        upstreamHost: "",
+        renderer: "raw",
+        bin: "junie",
+        // Also the catch-all for "raw"/not sure — see the OpenCode and Pi
+        // entries above for why an OpenAI-compatible guess is the better
+        // default for an unidentified custom server.
+        customTemplateFor: ["openai", "raw"],
+        setup: [
+          junieConfig(
+            "{baseUrl}",
+            "OpenAI",
+            "Authorization: Bearer YOUR_OPENAI_API_KEY"
+          ),
+        ],
+        notes: [JUNIE_NOTE, JUNIE_MERGE_NOTE],
+      },
+    ],
+  },
+  {
     id: "amp",
     label: "Amp",
     reason:
@@ -699,7 +801,14 @@ export function listAgents(): AgentSummary[] {
     id: agent.id,
     label: agent.label,
     supported: agent.providers != null,
-    needsProvider: (agent.providers?.length ?? 0) > 1,
+    // An alwaysCustom agent never shows the provider question — askChoice
+    // skips straight past it (see agent.alwaysCustom above) — regardless of
+    // how many internal templates its catalogue entry holds for
+    // findCustomTemplate to pick between. Junie is the first alwaysCustom
+    // agent with more than one, so this used to be true by coincidence for
+    // every alwaysCustom agent (OMP has exactly one provider); it is
+    // spelled out here now that a second one exists.
+    needsProvider: !agent.alwaysCustom && (agent.providers?.length ?? 0) > 1,
     alwaysCustom: agent.alwaysCustom === true,
   }));
   return [


### PR DESCRIPTION
## Summary

A student asked in `#ai-coding-crash-course` whether request-logger could work with Junie CLI. This wires it up.

- Junie is BYOK across several backends (OpenAI, Anthropic, Google, xAI, OpenRouter, Copilot, a LiteLLM proxy) with no fixed host of its own — the same shape OMP already has — so it's added as a second `alwaysCustom` agent.
- Unlike OMP, Junie's custom-proxy `config.json` declares a `kind` (protocol) per proxy entry, so the setup genuinely differs by wire format. Junie therefore gets **two** internal catalogue templates (`Anthropic`-kind and `OpenAI`-kind, tagged via `customTemplateFor`) instead of OMP's one — this is the first `alwaysCustom` agent to need that, so `listAgents().needsProvider` picked up a small correctness fix (`!agent.alwaysCustom && …`) so it doesn't misreport `true` for an agent whose provider question is never actually shown.
- Junie has no existing login to pass through the way Claude Code/Codex do — its custom proxy bypasses JetBrains AI auth entirely, so the printed config carries a placeholder header and a note telling the student to paste in a real key themselves, and not to commit the file.
- Junie CLI is closed source, so this entry is verified against JetBrains' published docs only (`config.json`, custom proxies, CLI reference), not driven against a real install — flagged in the README's "How much this was tested" section the same way Vertex AI's docs-only verification already is.

## Test plan

- [x] `npx vitest run` — all 561 tests pass (188 in `agents.test.ts`, including new Junie coverage: catalogue shape, `needsProvider`, template selection by wire format including the `raw` → OpenAI-kind default, header/kind separation between routes, merge/auth notes, stale-provider and no-base-URL error paths)
- [x] `npx tsc --noEmit` — no new errors (pre-existing, unrelated route-typegen errors only)
- [x] `npx prettier --check` on changed source files

🤖 Generated with [Claude Code](https://claude.com/claude-code)