### PR TITLE
request-logger: add Antigravity CLI support

### DIFF
--- a/request-logger/README.md
+++ b/request-logger/README.md
@@ -104,18 +104,19 @@ logged.
 The tool prints the correct command for you, so you do not have to copy anything
 from this table. It is here so you can see what is supported before you start.
 
-| Agent          | Works | What you need                                 |
-| -------------- | ----- | --------------------------------------------- |
-| Claude Code    | Yes   | One command. Works with a subscription login, an Anthropic API key, or Google Vertex AI. |
-| Codex          | Yes   | One flag. A subscription or an API key works. |
-| GitHub Copilot | Yes   | Your normal subscription login.               |
-| OpenCode       | Yes   | One command, or a config file.                |
-| Pi             | Yes   | A config file. Pi has no base URL variable.   |
-| OMP            | Yes   | A YAML config file. Point it at any backend.  |
-| Gemini CLI     | Yes   | One command. The free Google login works.     |
-| Junie          | Yes   | A config file, and a real API key pasted in — see below. |
-| Cursor CLI     | No    | Nothing can make it work. See below.          |
-| Amp            | No    | Nothing can make it work. See below.          |
+| Agent           | Works | What you need                                                                            |
+| --------------- | ----- | ---------------------------------------------------------------------------------------- |
+| Claude Code     | Yes   | One command. Works with a subscription login, an Anthropic API key, or Google Vertex AI. |
+| Codex           | Yes   | One flag. A subscription or an API key works.                                            |
+| GitHub Copilot  | Yes   | Your normal subscription login.                                                          |
+| OpenCode        | Yes   | One command, or a config file.                                                           |
+| Pi              | Yes   | A config file. Pi has no base URL variable.                                              |
+| OMP             | Yes   | A YAML config file. Point it at any backend.                                             |
+| Gemini CLI      | Yes   | One command. The free Google login works.                                                |
+| Antigravity CLI | Yes   | A config file and a real Gemini API key — see below.                                     |
+| Junie           | Yes   | A config file, and a real API key pasted in — see below.                                 |
+| Cursor CLI      | No    | Nothing can make it work. See below.                                                     |
+| Amp             | No    | Nothing can make it work. See below.                                                     |
 
 Any other provider — a local model server, or a smaller hosted one — works
 through **Custom base URL**, above, on any agent in this table except Cursor
@@ -135,6 +136,32 @@ logs folder stays empty with no error at all.
 This route only covers `CLOUD_ML_REGION=global`, the default and most common
 setting. A regional value (`us-east5`, say) talks to a different host and
 is not wired up yet — ask for it via the issue tracker if you hit this.
+
+### Antigravity CLI
+
+Antigravity CLI (`agy`) is a separate Google product from Gemini CLI — a
+different binary, a different agent harness — not a rebrand of it. Its API-key
+route, though, stores its settings under Gemini CLI's own directory
+(`~/.gemini/antigravity-cli/settings.json`) and calls the public Gemini API
+directly, reading the exact same `GOOGLE_GEMINI_BASE_URL` variable Gemini
+CLI's own API-key route reads. That means the existing `gemini` renderer
+already reads this capture correctly — no new wire format was needed, only a
+catalogue entry.
+
+Two things must both be true before Antigravity CLI takes this route at all,
+rather than falling back to its own account sign-in:
+
+- `modelProvider` is `"gemini"` in the settings file the wizard writes for you, and
+- `GEMINI_API_KEY` is exported in your shell — this tool does not set it, the
+  same way it does not set `ANTHROPIC_API_KEY` for Claude Code's own API-key
+  route.
+
+Only this API-key route is covered. Antigravity CLI's default account
+sign-in was not verified — Antigravity CLI is closed source, and public
+reporting on the related Antigravity IDE suggests its account-login traffic
+can go to a different, internal host rather than the Code Assist host Gemini
+CLI's own free login uses. Ask for it via the issue tracker if you need it
+logged.
 
 ### Junie
 
@@ -322,6 +349,12 @@ Be fair to the tool when you judge a failure.
   against a real Junie install. If the proxy `kind`, the config file's
   precise shape, or the header format is wrong, that is the likely reason,
   and the fix is one line in `agents.ts`.
+- **Antigravity CLI is verified against published docs only, the same way
+  Junie is.** Antigravity CLI is also closed source. Its API-key route was
+  checked against Google's own Antigravity CLI documentation (installation,
+  authentication and the `GOOGLE_GEMINI_BASE_URL` variable), not against real
+  source or a real install, and its account sign-in route was not verified
+  at all — see "Antigravity CLI" above for why that route is left out.
 - **A custom base URL is only as tested as the agent it is attached to.** The
   base URL and wire format mechanism itself is tested directly (see
   `agents.test.ts`); a specific third-party server behind it has not

--- a/request-logger/agents.test.ts
+++ b/request-logger/agents.test.ts
@@ -83,6 +83,7 @@ describe("listAgents", () => {
       "pi",
       "omp",
       "gemini",
+      "antigravity",
       "junie",
       "cursor",
       "amp",
@@ -301,6 +302,15 @@ describe("resolveChoice — upstream hosts", () => {
       target("gemini", "google-login").upstreamHost
     );
   });
+
+  it("sends Antigravity CLI's API key route to the same public API host as Gemini CLI's", () => {
+    expect(target("antigravity", "api-key").upstreamHost).toBe(
+      "generativelanguage.googleapis.com"
+    );
+    expect(target("antigravity", "api-key").upstreamHost).toBe(
+      target("gemini", "api-key").upstreamHost
+    );
+  });
 });
 
 describe("resolveChoice — renderers", () => {
@@ -336,6 +346,10 @@ describe("resolveChoice — renderers", () => {
   it("reads both Gemini routes with the Gemini renderer", () => {
     expect(target("gemini", "api-key").renderer).toBe("gemini");
     expect(target("gemini", "google-login").renderer).toBe("gemini");
+  });
+
+  it("reads Antigravity CLI with the Gemini renderer too, since it speaks the same wire format", () => {
+    expect(target("antigravity", "api-key").renderer).toBe("gemini");
   });
 });
 
@@ -487,6 +501,12 @@ describe("resolveChoice — commands", () => {
     );
     expect(target("gemini", "google-login").command).not.toContain(
       "GOOGLE_GEMINI_BASE_URL"
+    );
+  });
+
+  it("runs agy, not gemini, for Antigravity CLI", () => {
+    expect(target("antigravity", "api-key").command).toBe(
+      "GOOGLE_GEMINI_BASE_URL=http://localhost:8787 agy"
     );
   });
 
@@ -667,6 +687,27 @@ describe("resolveChoice — notes and warnings", () => {
 
   it("tells a Gemini student the Google login is free", () => {
     expect(target("gemini", "google-login").notes.join(" ")).toContain("free");
+  });
+
+  it("writes Antigravity CLI's settings file with modelProvider set to gemini", () => {
+    const result = target("antigravity", "api-key");
+    expect(result.setup).toHaveLength(1);
+    expect(result.setup[0].path).toBe(
+      "~/.gemini/antigravity-cli/settings.json"
+    );
+    expect(result.setup[0].body).toContain('"modelProvider": "gemini"');
+  });
+
+  it("tells an Antigravity CLI student to also export GEMINI_API_KEY", () => {
+    expect(target("antigravity", "api-key").notes.join(" ")).toContain(
+      "GEMINI_API_KEY"
+    );
+  });
+
+  it("warns an Antigravity CLI student that the account sign-in route is not covered", () => {
+    expect(target("antigravity", "api-key").warnings.join(" ")).toContain(
+      "sign-in"
+    );
   });
 });
 

--- a/request-logger/agents.ts
+++ b/request-logger/agents.ts
@@ -335,6 +335,43 @@ const JUNIE_MERGE_NOTE =
   "the proxies entry and the provider key alongside whatever else is " +
   "already in that file.";
 
+/**
+ * Antigravity CLI (`agy`) is a separate Google product from Gemini CLI — a
+ * different binary, a different agent harness — but its API-key route stores
+ * its settings under Gemini CLI's own directory (`~/.gemini/...`) and, per
+ * Google's docs, calls the public Gemini API directly and reads the exact
+ * same GOOGLE_GEMINI_BASE_URL variable Gemini CLI's own API-key route does.
+ * The existing "gemini" renderer already reads that wire format correctly,
+ * so this entry needed no renderer of its own — only a catalogue entry with
+ * the right bin and the settings file that switches this route on.
+ */
+const ANTIGRAVITY_NOTE =
+  "Antigravity CLI is a different product from Gemini CLI, with its own " +
+  "binary (agy, not gemini). This route works the same as Gemini CLI's API " +
+  "key route, though: both call the public Gemini API directly and read the " +
+  "same GOOGLE_GEMINI_BASE_URL variable, so the existing gemini renderer " +
+  "reads this capture correctly with no changes.";
+
+const ANTIGRAVITY_KEY_NOTE =
+  "GEMINI_API_KEY must also be exported in your shell, and modelProvider " +
+  'must be "gemini" in the settings file below. Without both, Antigravity ' +
+  "CLI falls back to its own account sign-in instead — a different, " +
+  "unverified route this catalogue does not cover yet (see the warning below).";
+
+const ANTIGRAVITY_MERGE_NOTE =
+  "This is merged into ~/.gemini/antigravity-cli/settings.json, not a " +
+  "replacement for it — add modelProvider alongside whatever else is " +
+  "already in that file.";
+
+const ANTIGRAVITY_LOGIN_WARNING =
+  "This entry covers the Gemini API key route only. Antigravity CLI's " +
+  "default account sign-in was not verified against real source (it is " +
+  "closed source) or a real login, and public reporting on the Antigravity " +
+  "IDE suggests its account-login traffic can go to a different, internal " +
+  "host rather than the Code Assist host Gemini CLI's own free login uses — " +
+  "so this catalogue does not claim that route works. Ask for it via the " +
+  "issue tracker if you need it logged.";
+
 const OPENCODE_NOTE =
   "The environment variable above works, but only by accident: OpenCode passes " +
   "no base URL of its own for this provider, so the bundled SDK falls back to " +
@@ -703,6 +740,29 @@ const AGENTS: AgentEntry[] = [
             "account login, and CODE_ASSIST_ENDPOINT is ignored under an API key. " +
             "Neither one gives you an error. You just get an empty logs folder.",
         ],
+      },
+    ],
+  },
+  {
+    id: "antigravity",
+    label: "Antigravity CLI",
+    providers: [
+      {
+        id: "api-key",
+        label: "Gemini API key",
+        upstreamHost: "generativelanguage.googleapis.com",
+        renderer: "gemini",
+        env: [["GOOGLE_GEMINI_BASE_URL", "{baseUrl}"]],
+        bin: "agy",
+        setup: [
+          {
+            path: "~/.gemini/antigravity-cli/settings.json",
+            language: "json",
+            body: ["{", '  "modelProvider": "gemini"', "}"].join("\n"),
+          },
+        ],
+        notes: [ANTIGRAVITY_NOTE, ANTIGRAVITY_KEY_NOTE, ANTIGRAVITY_MERGE_NOTE],
+        warnings: [ANTIGRAVITY_LOGIN_WARNING],
       },
     ],
   },


### PR DESCRIPTION
## Summary
- A student asked in `#crash-course-questions` whether Antigravity CLI (`agy`) needs its own request-logger setup or is the same as Gemini CLI: https://discord.com/channels/1316387060357140520/1539336140912464012/1542159633290887298
- Antigravity CLI is a separate Google product (different binary, different agent harness), **but** its API-key route stores settings under Gemini CLI's own directory (`~/.gemini/antigravity-cli/settings.json`) and calls the public Gemini API directly, reading the exact same `GOOGLE_GEMINI_BASE_URL` variable Gemini CLI's API-key route reads — so the existing `gemini` renderer already reads the capture correctly. Adds one catalogue entry (bin `agy`, same host/renderer/env as Gemini CLI's API-key route, plus the settings-file write that turns the API-key route on).
- Antigravity CLI's default account sign-in route is **not** covered — it's closed source, and public reporting on the related Antigravity IDE suggests its account-login traffic may go to a different internal host, so this stays unverified and is called out as a warning + README caveat rather than guessed at.

```mermaid
flowchart LR
    subgraph Bins["coding agent binaries"]
        gemini["gemini\n(Gemini CLI)"]
        agy["agy\n(Antigravity CLI)"]
    end

    subgraph Routes["provider routes"]
        glogin["google-login\nCODE_ASSIST_ENDPOINT"]
        gkey["api-key\nGOOGLE_GEMINI_BASE_URL"]
        akey["api-key\nGOOGLE_GEMINI_BASE_URL"]
        asignin["account sign-in\n(no override var known)"]
    end

    subgraph Hosts["upstream host"]
        cloudcode["cloudcode-pa.googleapis.com"]
        generative["generativelanguage.googleapis.com"]
        unknown["??? internal host\n(unverified)"]
    end

    renderer(["gemini renderer\n(render.ts)"])

    gemini --> glogin --> cloudcode --> renderer
    gemini --> gkey --> generative --> renderer
    agy --> akey --> generative --> renderer
    agy -.-> asignin -.-> unknown

    classDef new fill:#e6f4ea,stroke:#1a7f37,stroke-width:2px;
    classDef uncovered fill:#fff5f5,stroke:#cf222e,stroke-width:1.5px,stroke-dasharray: 4 3;
    class agy,akey new;
    class asignin,unknown uncovered;
```

`agy`'s API-key route (green) reuses the identical env var, host, and renderer as `gemini`'s own API-key route — that's why no new renderer was needed, just a catalogue entry. `agy`'s account sign-in (red, dashed) is the one path left out, since its host isn't verified.

## Test plan
- [x] `npx vitest run request-logger` — 289 passed
- [x] `npx tsc --noEmit` — no new errors (pre-existing, unrelated `.react-router` type errors confirmed present on `main` too)
- [x] `npx prettier --check` on changed files