### PR TITLE
chore: bump ai-hero-cli to 0.7.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
         "@types/react": "^19.2.7",
         "@types/react-dom": "^19.2.3",
         "@types/youtube": "^0.1.2",
-        "ai-hero-cli": "0.6.2",
+        "ai-hero-cli": "0.7.0",
         "drizzle-kit": "^0.31.4",
         "prettier": "^3.8.1",
         "shadcn": "^3.8.4",
@@ -4784,9 +4784,9 @@
       }
     },
     "node_modules/ai-hero-cli": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/ai-hero-cli/-/ai-hero-cli-0.6.2.tgz",
-      "integrity": "sha512-ArxdSnS8Vgw+FEXr6HxxfruKXrYKUBURhysZgaBbkiOR1EndTBwHhw+Iwi1hLK9R9ePTvWrSC6VAHW00V4YwEg==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/ai-hero-cli/-/ai-hero-cli-0.7.0.tgz",
+      "integrity": "sha512-/egqbjSnfat0UTbM1oQe7kU9yUWu7qflNzXuZ0m1IkbHK1d87fnjs/sOjIeor10sTDY7PQLHPTpZhP0Cb4mc1g==",
       "dev": true,
       "license": "MIT",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "@types/react": "^19.2.7",
     "@types/react-dom": "^19.2.3",
     "@types/youtube": "^0.1.2",
-    "ai-hero-cli": "0.6.2",
+    "ai-hero-cli": "0.7.0",
     "drizzle-kit": "^0.31.4",
     "prettier": "^3.8.1",
     "shadcn": "^3.8.4",


### PR DESCRIPTION
## Summary
- Bumps the pinned `ai-hero-cli` devDependency from `0.6.2` to `0.7.0` (exact, matching how it's pinned).
- Picks up [mattpocock/ai-hero-cli#79](https://github.com/mattpocock/ai-hero-cli/pull/79): `npm run reset` now warns when a lesson has git-tracked symlinks and this repo's checkout has `core.symlinks=false` — the case where Windows without Developer Mode/admin rights checks a symlink out as a plain text file instead of a real link (root cause of a student report in #crash-course-questions).

## Test plan
- [x] `npm install --save-exact --save-dev ai-hero-cli@0.7.0` — clean, minimal `package.json`/`package-lock.json` diff (version bump only).
- [x] `npx ai-hero-cli reset --help` runs fine against the new version.
- [ ] After merge: rebase `live-run-through` onto the new `main` tip so students on that branch pick this up too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)