### PR TITLE
fix(request-logger): make Codex command shell-portable

### DIFF
--- a/request-logger/README.md
+++ b/request-logger/README.md
@@ -328,7 +328,7 @@ of these happened:
 5. **You are on an older Codex, or following an older guide.** Codex used to
    read an OPENAI_BASE_URL variable. Version 0.133.0 does not. It ignores the
    variable in silence, so the only sign is an empty logs folder. Use the
-   command this tool prints.
+   command this tool prints exactly, including its quote placement.
 
 ## How much this was tested
 

--- a/request-logger/agents.test.ts
+++ b/request-logger/agents.test.ts
@@ -450,13 +450,13 @@ describe("resolveChoice — commands", () => {
   it("sets the base URL for Codex on an API key", () => {
     // Codex 0.133.0 has no OPENAI_BASE_URL. The flag is the only door.
     expect(target("codex", "openai").command).toBe(
-      `codex -c 'openai_base_url="http://localhost:8787/v1"'`
+      `codex -c openai_base_url='http://localhost:8787/v1'`
     );
   });
 
   it("sets the base URL for Codex on a ChatGPT subscription", () => {
     expect(target("codex", "chatgpt").command).toBe(
-      `codex -c 'openai_base_url="http://localhost:8787/backend-api/codex"'`
+      `codex -c openai_base_url='http://localhost:8787/backend-api/codex'`
     );
   });
 
@@ -565,11 +565,10 @@ describe("resolveChoice — commands on win32", () => {
   });
 
   it("leaves Codex's flag-based override unchanged", () => {
-    // Codex has no env var override — its whole command is a `-c` flag,
-    // single-quoted. PowerShell parses a single-quoted literal the same way
-    // bash does (no interpolation), so this needs no rewriting.
+    // Codex has no env var override — its whole command is a `-c` flag. This
+    // quote placement works in PowerShell, POSIX shells, and cmd.exe.
     expect(winTarget("codex", "openai").command).toBe(
-      `codex -c 'openai_base_url="http://localhost:8787/v1"'`
+      `codex -c openai_base_url='http://localhost:8787/v1'`
     );
   });
 });

--- a/request-logger/agents.ts
+++ b/request-logger/agents.ts
@@ -225,8 +225,7 @@ interface AgentEntry {
 const CODEX_OVERRIDE_NOTE =
   "The -c flag sets this for one run only. Your ~/.codex/config.toml is not " +
   "touched, so your normal Codex is unchanged the moment you stop using this " +
-  "command. Keep the quotes exactly as they are: Codex reads the value as TOML, " +
-  "and an unquoted URL does not parse.";
+  "command. Keep the quotes exactly as they are.";
 
 const PI_NOTE =
   "Pi has no base URL variable and no flag. A config file is the only way to " +
@@ -474,7 +473,7 @@ const AGENTS: AgentEntry[] = [
         // which is https://chatgpt.com/backend-api/codex.
         suffix: "/backend-api/codex",
         bin: "codex",
-        args: ["-c", `'openai_base_url="{baseUrl}"'`],
+        args: ["-c", "openai_base_url='{baseUrl}'"],
         notes: [CODEX_OVERRIDE_NOTE],
       },
       {
@@ -486,7 +485,7 @@ const AGENTS: AgentEntry[] = [
         // appends `responses` to it, so the base URL keeps the /v1.
         suffix: "/v1",
         bin: "codex",
-        args: ["-c", `'openai_base_url="{baseUrl}"'`],
+        args: ["-c", "openai_base_url='{baseUrl}'"],
         // The only usable template for a custom Codex target: Codex only
         // ever speaks the OpenAI-compatible wire format, so it is the
         // catch-all for every choice, including "anthropic" — a mismatch


### PR DESCRIPTION
## Summary

The request logger printed Codex commands with the entire
`openai_base_url` override wrapped in single quotes:

```sh
codex -c 'openai_base_url="http://localhost:8787/backend-api/codex"'
```

`cmd.exe` treats those single quotes as literal characters, so Codex ignored
the override and bypassed the request logger.

Move the quotes inside the assignment:

```sh
codex -c openai_base_url='http://localhost:8787/backend-api/codex'
```

The new syntax works in `cmd.exe`, PowerShell, and POSIX shells. The
troubleshooting guidance now tells users to copy the generated command exactly,
including its quote placement.

## Test plan

- [x] Prettier passes on all changed files
- [x] `npm run typecheck`
- [x] Focused Codex suite — 10 tests passed
- [x] `npm run build`
- [x] `git diff --check`
- [x] Manually verified the new quote placement in `cmd.exe`, PowerShell, Git Bash, and WSL Bash

The complete test run passed 571 tests. Two unrelated OpenCode tests could not
run on Windows because they invoke `/bin/sh` by absolute path.
